### PR TITLE
Insere dicas para contribuições da comunidade

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Código de Conduta
+
+Este código de conduta delineia nossas expectativas para os participantes dentro da comunidade, bem como as etapas para relatar comportamento inaceitável. Estamos comprometidos em fornecer uma comunidade acolhedora e inspiradora para todos e esperamos que nosso código de conduta seja honrado. Qualquer pessoa que viole este código de conduta pode ser banida da comunidade.
+
+
+## Nosso Compromisso
+
+No interesse de promover um ambiente aberto e acolhedor, nós, como colaboradores e mantenedores, comprometemo-nos a tornar a participação em nosso projeto e em nossa comunidade uma experiência livre de assédio para todos, independentemente da idade, tamanho do corpo, deficiência, etnia, identidade e expressão de gênero, nível de experiência, nacionalidade, aparência pessoal, raça, religião, status social e econômico ou identidade e orientação sexual.
+
+## O que acreditamos e como agimos 
+
+- Nossa comunidade é baseada no respeito mútuo, tolerância e encorajamento.
+- Acreditamos que uma comunidade diversificada onde as pessoas se tratam com respeito é mais forte, mais vibrante e tem mais contribuintes em potencial e mais fontes de ideias. 
+- Nosso objetivo é ter mais diversidade.
+- Somos gentis, acolhedores e corteses com todos.
+- Somos respeitosos com os outros, suas posições, suas habilidades, seus compromissos e seus esforços.
+- Respeitamos que as pessoas tenham diferenças de opinião.
+- Estamos atentos às nossas comunicações, seja pessoalmente ou on-line, e temos o cuidado de abordar pontos de vista diferentes.
+- Estamos conscientes de que a linguagem molda a realidade. Assim, usamos linguagem inclusiva e neutra em termos de gênero nos documentos que fornecemos e quando falamos com as pessoas.
+- Ao nos referirmos a um grupo de pessoas, pretendemos usar termos neutros de gênero, como "equipe", "pessoal", "todos". (Para detalhes, recomendamos este post).
+
+## Exemplos de NÃOs:
+
+- Não seja malvado ou grosseiro.
+- Não discrimine ninguém.
+- O sexismo e racismo de qualquer tipo (incluindo “piadas” sexistas e racistas), humilhando ou insultando o comportamento e o assédio são vistos como violações diretas a este Código de Conduta. O assédio inclui comentários verbais ofensivos relacionados a idade, tamanho do corpo, cultura, etnia, expressão de gênero, identidade de gênero, nível de experiência, nacionalidade, capacidade ou deficiência pessoal, aparência física, diferença física ou mental, raça, religião, conjunto de habilidades orientação, status social e econômico. O assédio também inclui imagens sexuais em espaços públicos, intimidação deliberada, perseguição, fotografia ou gravação de assédio, contato físico inadequado e atenção sexual indesejada.
+- Respeite que alguns indivíduos e culturas consideram o uso ocasional de palavrões ofensivo e desconcertante.
+- Desvios, argumentos de tom e outras formas de jogar com os desejos das pessoas de serem gentis não são bem-vindos, especialmente em discussões sobre violações a este Código de Conduta.
+- Por favor, evite críticas não construtivas.
+- Da mesma forma, qualquer spamming, trolling, flaming, baiting ou outro comportamento de roubo de atenção não é bem-vindo.
+- Patrocinadores do vindi-woocommerce-subscriptions também estão sujeitos a este Código de Conduta. Em particular, os patrocinadores são obrigados a não usar imagens sexualizadas, atividades ou outro material que não esteja de acordo com este Código de Conduta.
+
+## Nossas Responsabilidades
+
+Os mantenedores do projeto são responsáveis por esclarecer os padrões de comportamento aceitável e devem tomar medidas corretivas apropriadas e justas em resposta a quaisquer casos de comportamento inaceitável.
+
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições do wiki, questões e outras contribuições que não estejam alinhadas a este Código de Conduta, ou banir temporariamente ou permanentemente qualquer colaborador por outros comportamentos que julgam inapropriado, ameaçador, ofensivo ou prejudicial.
+
+## Escopo
+
+Este Código de Conduta se aplica tanto nos espaços do projeto quanto nos espaços públicos quando um indivíduo está representando o projeto ou sua comunidade. Exemplos de representação de um projeto ou comunidade incluem o uso de um endereço de e-mail oficial do projeto, postagem por meio de uma conta oficial de mídia social ou a atuação como um representante nomeado em um evento on-line ou off-line. A representação de um projeto pode ser definida e esclarecida pelos mantenedores do projeto.
+
+## Cumprimento
+
+Casos de comportamento abusivo, ofensivo ou inaceitável podem ser relatados entrando em contato com a equipe do projeto em comunidade@vindi.com.br. A equipe do projeto analisará e investigará todas as reclamações e responderá da maneira que julgar apropriada às circunstâncias. A equipe do projeto é obrigada a manter a confidencialidade em relação ao relator de um incidente. Detalhes adicionais de políticas de execução específicas podem ser publicados separadamente. Esse código de conduta delineia nossas expectativas para os participantes da comunidade vindi-woocommerce-subscriptions, bem como as etapas para relatar comportamento inaceitável. Estamos comprometidos em fornecer uma 
+acolhedora e inspiradora para todos e esperamos que nosso código de conduta seja honrado. Qualquer pessoa que viole este código de conduta pode ser banida da comunidade.
+
+Os mantenedores do projeto que não seguem ou aplicam o Código de Conduta de boa fé podem enfrentar repercussões temporárias ou permanentes, conforme determinado por outros membros da liderança do projeto.
+
+## Atribuição
+
+Este Código de Conduta foi uma adaptação do [Contributor Covenant] [homepage], versão 1.4, disponível em http://contributor-covenant.org/version/1/4
+
+[homepage]: http://contributor-covenant.org
+[versão]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contribuindo para o Vindi-Woocommerce
+
+:clap::grin: Antes de mais nada, muito obrigado por sua contribuição  :thumbsup:
+
+Este projeto e todos os participantes estão sob o regimento do [**Código de Conduta Vindi**](CODE_OF_CONDUCT.md). Ao participar, espera-se que você mantenha este código.
+
+**Contribuições** são **muito bem vindas** e serão totalmente [**creditadas**](https://github.com/vindi/vindi-woocommerce/graphs/contributors).
+
+Nós valorizamos muito as [**contribuições por Pull Requests (PR)**](https://github.com/vindi/vindi-woocommerce/pulls) em [GitHub](https://github.com/vindi/vindi-woocommerce), mas também adoramos **sugestões de novas features**. Por isso, fique à vontade para **reportar um bug :rotating_light:** ou **parabenizar :tada: o projeto!**
+
+## Requisitos de um bom Pull Request (PR) para vindi-woocommerce
+
+- **Branches separadas** - Recomendamos que o PR não seja a partir da sua branch `master`.
+
+- **Um PR por feature** - Se você deseja ajudar em mais de uma feature, envie múltiplos PRs :grin:.
+
+- **Clareza** - Além de uma boa descrição sobre a motivação e a solução proposta é possível incluir imagens ou animações que demonstrem quaisquer modificações visuais na interface. 
+
+Exemplo de **Motivação** com uma **Solução Proposta**:
+> Motivação
+
+> Fazer com que o pedido seja cancelado, caso o pagamento seja reprovado na primeira tentativa (compras avulsas ou primeiro ciclo de uma assinatura), mas atualmente o cliente recebe a informação que o pedido foi registrado com sucesso, e posteriormente recebe a informação de falha no pagamento no Woocommerce.
+
+> Solução proposta
+
+> Adicionar o cancelamento automático de faturas na Vindi após a recusa de uma transação no Woocommerce, exceto: compras via Boleto ou pendente de revisões do Antifraude.
+
+- **Foco** - Um PR deve possuir um único objetivo bem definido. Evite mais de um viés (bug-fix, feature, refactoring) no mesmo PR.
+
+- **Formatação de código** - Não reformate código que não foi modificado. A reformatação de código deve ser feita exclusiva e obrigatoriamente nos trechos de código que foram afetados pelo contexto da sua alteração.
+Obs.: Gostamos muito do [WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/) :smile:
+
+- **Fragmentação** - Quando um PR for parte de uma tarefa e não entregar valor de forma isolada, será necessário explicitar na motivação quais são os objetivos da tarefa, e na solução proposta, os objetivos que foram concluídos no PR em questão e os que serão concluídos em PRs futuros.
+
+#### Se você nunca criou um Pull Request (PR) na vida, seja bem vindo :tada: :smile: [Aqui está um ótimo tutorial](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) de como enviar um.
+
+1. Faça um [fork](http://help.github.com/fork-a-repo/) do projeto, clone seu repositório (fork):
+
+   ```bash
+   # Clone repositório (fork) na pasta corrente
+   git clone https://github.com/<seu-username>/vindi-woocommerce
+   # Navegue ate a pasta recém clonada
+   cd vindi-woocommerce
+   ```
+
+2. Crie uma branch nova a partir da `master` que vai conter o "tipo/tópico" como nome da branch
+- tipos: feature e fix
+
+   ```bash
+   git checkout -b feature/cria_metodo_pagamento
+   ```
+
+3. Faça um push da sua branch para seu repositório (fork) 
+
+   ```bash
+   git push -u origin feature/cria_metodo_pagamento
+   ```
+
+4. [Abra um Pull Request](https://help.github.com/articles/using-pull-requests/) com uma motivação e solução proposta bem claras.
+
+
+## Revisão da Comunidade
+
+A revisão deve verificar se o PR atende aos requisitos abaixo, na ordem que são apresentados, e a decisão final ficaria com a 
+equipe Vindi quanto à prioridade:
+
+#### Correto
+
+- O código realmente faz o que o autor está propondo?
+- O tratamento de erros está adequado?
+
+#### Seguro
+
+- As modificações introduzem vulnerabilidades de segurança?
+- Dados sensíveis estão sendo tratados da maneira correta?
+
+#### Legível
+
+- O código está legível?
+- Métodos, classes e variáveis foram nomeadas apropriadamente?
+- Os padrões definidos pelo projeto ou pela equipe estão sendo respeitados?
+
+## 
+**Feliz desenvolvimento!**

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Motivação
+Descrição concisa e clara do motivo da criação do Pull Request (PR).
+
+## Solução Proposta
+Descrição, também concisa e clara :grin: de sua solução.


### PR DESCRIPTION
### Motivação
Não existem padrões para contribuições da comunidade.
Isso pode fazer com que as contribuições não fiquem tão claras para revisão de aceitação do time Vindi.

### Solução proposta
Inserir templates para novas contribuições que facilitem a interação entre Vindi x Comunidade