### PR TITLE
Corrige processo de renovação de assinatura

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,14 +4,14 @@ Plugin Name: Vindi WooCommerce 2 (BETA)
 Plugin URI: https://github.com/vindi/vindi-woocommerce
 Website Link: https://www.vindi.com.br
 Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança-recorrente, recurring, site-de-assinatura, assinaturas, faturamento-recorrente, recorrencia, assinatura, woocommerce-subscriptions, vindi-woocommerce, vindi-payment-gateway
-Author URI: https://mentores.com.br/
-Author: Mentores Digital
+Author URI: https://vindi.com.br/ | https://mentores.com.br
+Author: Vindi | Mentores Digital
 Requires at least: 4.4
-Tested up to: 5.4.2
+Tested up to: 5.5.3
 WC requires at least: 3.0.0
-WC tested up to: 4.2.1
+WC tested up to: 4.7.1
 Requires PHP: 5.6
-Stable Tag: 1.0.2
+Stable Tag: 1.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,14 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.0.3 - 08/12/2020 =
+- Lançamento da versão de patch.
+- **Correção**: Corrigida a falha no ciclo de renovação de assinaturas.
+- **Correção**: Corrigida a falha em assinaturas de planos com período trial.
+- **Correção**: Corrigida a falha na função de sincronismo de assinaturas.
+- **Adição**: Compatibilidade nas renovações de assinatura do plugin anterior. 
+
+
 = 1.0.2 - 25/11/2020 =
 - Lançamento da versão de patch.
 - **Correção**: Corrigido a falha crítica na adesão de assinaturas por boleto e cartão.
@@ -65,10 +73,8 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.0.2 - 25/11/2020 =
-Patch de correções para o plugin da Vindi
-= 1.0.1 - 28/10/2020 =
-Patch de correções para o plugin da Vindi
+= 1.0.3 - 08/12/2020 =
+Patch de correções para o plugin Vindi
 
 == License ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,6 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 - Lançamento da versão de patch.
 - **Correção**: Corrigida a falha no ciclo de renovação de assinaturas.
 - **Correção**: Corrigida a falha em assinaturas de planos com período trial.
-- **Correção**: Corrigida a falha na função de sincronismo de assinaturas.
 - **Adição**: Compatibilidade nas renovações de assinatura do plugin anterior. 
 
 

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -180,7 +180,7 @@ class VindiWebhooks
     }
     update_post_meta($order->id, 'vindi_order', $vindi_order);
 
-    // As informações sobre o pedido são atualizadas sempre no último elemento do array
+    // Order informations always be updated in last array element
     $vindi_order_info = end($vindi_order);
 
     if ($vindi_order_info['bill']['status'] == 'paid') {

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -180,20 +180,13 @@ class VindiWebhooks
     }
     update_post_meta($order->id, 'vindi_order', $vindi_order);
 
-    $all_bills_paid = [];
-    foreach ($vindi_order as $item) {
-      if ($item['bill']['status'] == 'paid') {
-        array_push($all_bills_paid, true);
-      } else {
-        array_push($all_bills_paid, false);
-      }
-    }
+    // As informações sobre o pedido são atualizadas sempre no último elemento do array
+    $vindi_order_info = end($vindi_order);
 
-    if(!empty($all_bills_paid) && !in_array(false, $all_bills_paid)) {
-      $new_status = $this->vindi_settings->get_return_status();
-      $order->update_status($new_status, __('O Pagamento foi realizado com sucesso pela Vindi.',
-        VINDI));
-      $this->update_next_payment($data);
+    if ($vindi_order_info['bill']['status'] == 'paid') {
+        $new_status = $this->vindi_settings->get_return_status();
+        $order->update_status($new_status, __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI));
+        $this->update_next_payment($data);
     }
   }
 

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -300,7 +300,7 @@ class VindiWebhooks
   private function find_subscription_by_id($id)
   {
     // Webhooks Ids has "WC-" prefix
-    $sanitized_id = explode('-', $id);
+    $sanitized_id = explode('WC-', $id);
     $subscription = wcs_get_subscription(end($sanitized_id));
 
     if(empty($subscription))

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -288,7 +288,12 @@ class VindiWebhooks
     if ($this->vindi_settings->get_synchronism_status()){
       $subscription_id = $data->subscription->code;
       $subscription = $this->find_subscription_by_id($subscription_id);
-      $subscription->update_status('active', sprintf(__('Assinatura %s reativada pela Vindi.', VINDI), $subscription_id));
+      $order_id = $subscription->get_last_order();
+      $order = $this->find_order_by_id($order_id);
+      $status_available = array('processing', 'completed', 'on-hold');
+      if (in_array($order->get_status(), $status_available)) {
+          $subscription->update_status('active', sprintf(__('Assinatura %s reativada pela Vindi.', VINDI), $subscription_id));
+      }
     }
   }
 

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -306,7 +306,9 @@ class VindiWebhooks
    */
   private function find_subscription_by_id($id)
   {
-    $subscription = wcs_get_subscription($id);
+    // Webhooks Ids has "WC-" prefix
+    $sanitized_id = explode('-', $code);
+    $subscription = wcs_get_subscription(end($sanitized_id));
 
     if(empty($subscription))
       throw new Exception(sprintf(__('Assinatura #%s não encontrada!', VINDI), $id), 2);

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -307,7 +307,7 @@ class VindiWebhooks
   private function find_subscription_by_id($id)
   {
     // Webhooks Ids has "WC-" prefix
-    $sanitized_id = explode('-', $code);
+    $sanitized_id = explode('-', $id);
     $subscription = wcs_get_subscription(end($sanitized_id));
 
     if(empty($subscription))

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.0.0');
+define('VINDI_VERSION', '1.0.3');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -2,12 +2,15 @@
 
 /**
  * Plugin Name: Vindi WooCommerce 2 (BETA)
- * Plugin URI: #!
+ * Plugin URI: https://github.com/vindi/vindi-woocommerce
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.0.2
+ * Version: 1.0.3
  * Requires at least: 4.4
+ * Tested up to: 5.5.3
+ * WC requires at least: 3.0.0
+ * WC tested up to: 4.7.1
  * Text Domain: vindi-payment-gateway
  *
  * Domain Path: ./src/languages/


### PR DESCRIPTION
## O que mudou
Foi solucionado um problema que impedia a criação dos pedidos de renovação.

## Motivação
Devido a um envio incorreto ao consultar as assinaturas no WooCommerce está ocorrendo erros no envio dos webhooks.

## Solução proposta
Foi removido o prefixo **WC -** no id utilizado para consulta das assinaturas no WooCommerce.

## Como testar

1. Criar uma assinatura no WooCommerce;
2. Realizar a renovação manual da assinatura pela plataforma Vindi. 
