### PR TITLE
Insere verificação na assinatura antes de realizar cancelamentos

### DIFF
--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -495,5 +495,19 @@ class VindiRoutes
 
     return false;
   }
+
+    public function hasPendingSubscriptionBills($subscription_id)
+    {
+        $bill_subscription_id = filter_var($subscription_id, FILTER_SANITIZE_NUMBER_INT);
+        $query = urlencode("subscription_id={$bill_subscription_id} status=pending");
+
+        $response = $this->api->request('bills?query=' . $query, 'GET');
+
+        if (empty($response['bills'])) {
+            return false;
+        }
+
+        return true;
+    }
 }
 ?>

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -268,7 +268,8 @@ class VindiWebhooks
     if ($this->vindi_settings->get_synchronism_status()
       && ($subscription->has_status('cancelled')
       || $subscription->has_status('pending-cancel')
-      || $subscription->has_status('on-hold'))) {
+      || $subscription->has_status('on-hold'))
+      || $this->routes->hasPendingSubscriptionBills($data->subscription->id)) {
       return;
     }
 

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -285,23 +285,28 @@ class VindiWebhooks
         $subscription->update_status('cancelled');
   }
 
-  /**
-   * Process subscription_reactivated event from webhook
-   * @param $data array
-   */
-  private function subscription_reactivated($data)
-  {
-    if ($this->vindi_settings->get_synchronism_status()){
-      $subscription_id = $data->subscription->code;
-      $subscription = $this->find_subscription_by_id($subscription_id);
-      $order_id = $subscription->get_last_order();
-      $order = $this->find_order_by_id($order_id);
-      $status_available = array('processing', 'completed', 'on-hold');
-      if (in_array($order->get_status(), $status_available)) {
-          $subscription->update_status('active', sprintf(__('Assinatura %s reativada pela Vindi.', VINDI), $subscription_id));
-      }
+    /**
+    * Process subscription_reactivated event from webhook
+    * @param $data array
+    */
+    private function subscription_reactivated($data)
+    {
+        if ($this->vindi_settings->get_synchronism_status()
+            && !$this->routes->hasPendingSubscriptionBills($data->subscription->id))) {
+            $subscription_id = $data->subscription->code;
+            $subscription = $this->find_subscription_by_id($subscription_id);
+            $order_id = $subscription->get_last_order();
+            $order = $this->find_order_by_id($order_id);
+            $status_available = array('processing', 'completed', 'on-hold');
+
+            if (in_array($order->get_status(), $status_available)) {
+                $subscription->update_status(
+                    'active',
+                    sprintf(__('Assinatura %s reativada pela Vindi.', VINDI), $subscription_id)
+                );
+            }
+        }
     }
-  }
 
   /**
    * find a subscription by id

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -276,7 +276,12 @@ class VindiWebhooks
       $subscription->update_status('pending-cancel');
       return;
     }
-    $subscription->update_status('cancelled');
+
+    // Last safe check on subscription status before cancellation
+    $synchronized_subscription = $this->routes->getSubscription($data->subscription->id);
+
+    if ($synchronized_subscription['status'] === 'canceled')
+        $subscription->update_status('cancelled');
   }
 
   /**

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -292,7 +292,7 @@ class VindiWebhooks
     private function subscription_reactivated($data)
     {
         if ($this->vindi_settings->get_synchronism_status()
-            && !$this->routes->hasPendingSubscriptionBills($data->subscription->id))) {
+            && !$this->routes->hasPendingSubscriptionBills($data->subscription->id)) {
             $subscription_id = $data->subscription->code;
             $subscription = $this->find_subscription_by_id($subscription_id);
             $order_id = $subscription->get_last_order();


### PR DESCRIPTION
## O que mudou
Foi adicionada uma verificação do status da Assinatura na plataforma Vindi antes de realizar operações de cancelamento.

## Motivação
Em alguns casos de assinaturas reativadas via plataforma Vindi, a cobrança pode ocorrer instantaneamente, antes de ocorrer o correto processamento dos _webhooks_ no plugin.
Esse problema pode gerar o cancelamento permanente da assinatura, pois o retorno de "pausa" na assinatura devido a geração de uma nova fatura chega antes do retorno de fatura criada. Fazendo com que o plugin entenda a ação como cancelamento espontâneo.

## Solução proposta
- Inserir uma verificação de segurança no status da assinatura na plataforma Vindi antes de realizar o cancelamento de pedido (assinatura).
- Inserir um bloqueio no cancelamento de assinaturas via plataforma, caso a assinatura possua faturas em aberto.
Nesse caso, é necessário cancelar as faturas (pendências) da assinatura (via plataforma) ou realizar o cancelamento via plugin (WooCommerce):
![image](https://user-images.githubusercontent.com/31661772/103591216-43a44280-4ece-11eb-8ca4-6adb0f7c8419.png) 

## Como testar
- Criar uma assinatura diária
- Pausar a assinatura através do painel do WooCommerce ("minha conta")
- Reativar a assinatura no dia seguinte
- Se for realizada alguma cobrança o status da assinatura deve estar de acordo com última cobrança realizada