### PR TITLE
Adaptando o plugin para permitir compra de assinaturas variáveis cujos planos são diferentes

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -519,6 +519,13 @@ class VindiPaymentProcessor
         } else {
             $product = $this->get_product($order_items);
             $order_items['type'] = 'product';
+            
+            if ($this->is_variable($product)) {
+                $product_id = $order_items['variation_id'];
+            } else {
+                $product_id = $product->id;
+            }
+
             $get_vindi = $this->get_vindi_code($product->id);
             $order_items['vindi_id'] = $get_vindi ? $get_vindi : $product->vindi_id;
             if ($this->subscription_has_trial($product)) {
@@ -943,7 +950,7 @@ class VindiPaymentProcessor
 
         $type = $order_item->get_product()->get_type();
 
-        if ($type == 'subscription') {
+        if ($this->is_subscription_type($product) || $this->is_variable($product)) {
             $vindi_plan = $this->get_plan_from_order_item($order_item);
             $data['plan_id'] = $vindi_plan;
             $wc_subscription_id = VindiHelpers::get_matching_subscription($this->order, $order_item)->id;

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -292,15 +292,16 @@ class VindiPaymentProcessor
                 $interval = get_post_meta($product_id, '_subscription_period_interval', true);
                 $subscriptions_grouped_by_period[$period . $interval][] = $order_item;
                 array_push($subscription_products, $order_item);
+                continue;
             }
-            else {
-                array_push($bill_products, $order_item);
-            }
+            
+            array_push($bill_products, $order_item);
         }
 
         foreach ($subscriptions_grouped_by_period as $key => $subscription_group) {
             if (count($subscription_group) > 1) {
-                $this->abort(__('Não é permitido criar um único pedido com múltiplas assinaturas de mesma periodicidade ', VINDI), true);
+                $msg = 'Não é permitido criar um único pedido com múltiplas assinaturas de mesma periodicidade';
+                $this->abort(__($msg, VINDI), true);
             }
         }
         

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -946,6 +946,8 @@ class VindiPaymentProcessor
         $data['installments'] = $this->installments();
         $data['product_items'] = array();
 
+        $product = $order_item->get_product();
+
         if ($this->is_subscription_type($product) || $this->is_variable($product)) {
             $vindi_plan = $this->get_plan_from_order_item($order_item);
             $data['plan_id'] = $vindi_plan;

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -516,26 +516,25 @@ class VindiPaymentProcessor
 
             }
             return $order_items;
-        } else {
-            $product = $this->get_product($order_items);
-            $order_items['type'] = 'product';
-            $product_id = $product->id;
-            
-            if ($this->is_variable($product)) {
-                $product_id = $order_items['variation_id'];
-            }
-
-            $get_vindi = $this->get_vindi_code($product->id);
-            $order_items['vindi_id'] = $get_vindi ? $get_vindi : $product->vindi_id;
-            if ($this->subscription_has_trial($product)) {
-                $matching_item = $this->get_trial_matching_subscription_item($order_items);
-                $order_items['price'] = (float) $matching_item['subtotal'] / $matching_item['qty'];
-            } else {
-                $order_items['price'] = (float) $order_items['subtotal'] / $order_items['qty'];
-            }
-            return $order_items;
         }
 
+        $product = $this->get_product($order_items);
+        $order_items['type'] = 'product';
+        $product_id = $product->id;
+
+        if ($this->is_variable($product)) {
+            $product_id = $order_items['variation_id'];
+        }
+
+        $get_vindi = $this->get_vindi_code($product->id);
+        $order_items['vindi_id'] = $get_vindi ? $get_vindi : $product->vindi_id;
+        if ($this->subscription_has_trial($product)) {
+            $matching_item = $this->get_trial_matching_subscription_item($order_items);
+            $order_items['price'] = (float) $matching_item['subtotal'] / $matching_item['qty'];
+        } else {
+            $order_items['price'] = (float) $order_items['subtotal'] / $order_items['qty'];
+        }
+        return $order_items;
     }
 
     /**
@@ -946,8 +945,6 @@ class VindiPaymentProcessor
         $data['payment_method_code'] = $this->payment_method_code();
         $data['installments'] = $this->installments();
         $data['product_items'] = array();
-
-        $type = $order_item->get_product()->get_type();
 
         if ($this->is_subscription_type($product) || $this->is_variable($product)) {
             $vindi_plan = $this->get_plan_from_order_item($order_item);

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -291,7 +291,7 @@ class VindiPaymentProcessor
 
         $this->check_multiple_subscriptions_of_same_period($subscriptions_grouped_by_period);
         
-        foreach($subscription_products as $subscription_order_item) {
+        foreach ($subscription_products as $subscription_order_item) {
             if(empty($subscription_order_item))
                 continue;
 
@@ -366,7 +366,7 @@ class VindiPaymentProcessor
 
     private function check_multiple_subscriptions_of_same_period($subscriptions_grouped_by_period)
     {
-        foreach ($subscriptions_grouped_by_period as $key => $subscription_group) {
+        foreach ($subscriptions_grouped_by_period as $subscription_group) {
             if (count($subscription_group) > 1) {
                 $msg = 'Não é permitido criar um único pedido com múltiplas assinaturas de mesma periodicidade';
                 $this->abort(__($msg, VINDI), true);

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -291,7 +291,7 @@ class VindiPaymentProcessor
 
         $this->check_multiple_subscriptions_of_same_period($subscriptions_grouped_by_period);
         
-        foreach($subscription_products as $key => $subscription_order_item) {
+        foreach($subscription_products as $subscription_order_item) {
             if(empty($subscription_order_item))
                 continue;
 

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -526,7 +526,7 @@ class VindiPaymentProcessor
             $product_id = $order_items['variation_id'];
         }
 
-        $get_vindi = $this->get_vindi_code($product->id);
+        $get_vindi = $this->get_vindi_code($product_id);
         $order_items['vindi_id'] = $get_vindi ? $get_vindi : $product->vindi_id;
         if ($this->subscription_has_trial($product)) {
             $matching_item = $this->get_trial_matching_subscription_item($order_items);

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -509,7 +509,7 @@ class VindiPaymentProcessor
     {
         if ('bill' === $order_type) {
             foreach ($order_items as $key => $order_item) {
-                $product = $this->get_product($order_item);
+                $product = $order_item->get_product();
                 $order_items[$key]['type'] = 'product';
                 $order_items[$key]['vindi_id'] = $this->routes->findProductByCode('WC-' . $product->id)['id'];
                 $order_items[$key]['price'] = (float) $order_items[$key]['subtotal'] / $order_items[$key]['qty'];
@@ -518,7 +518,7 @@ class VindiPaymentProcessor
             return $order_items;
         }
 
-        $product = $this->get_product($order_items);
+        $product = $order_items->get_product();
         $order_items['type'] = 'product';
         $product_id = $product->id;
 

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -519,11 +519,10 @@ class VindiPaymentProcessor
         } else {
             $product = $this->get_product($order_items);
             $order_items['type'] = 'product';
+            $product_id = $product->id;
             
             if ($this->is_variable($product)) {
                 $product_id = $order_items['variation_id'];
-            } else {
-                $product_id = $product->id;
             }
 
             $get_vindi = $this->get_vindi_code($product->id);


### PR DESCRIPTION
## O que mudou
Agora o plugin permite compra de duas assinaturas que são variações do mesmo produto (ex.: tamanho P e G) e cujos planos são diferentes (ex.: um mensal e outro anual). As assinaturas são criadas separadamente na Vindi.

## Motivação
Ao tentar comprar duas assinaturas variáveis de planos diferentes, o plugin criava uma única assinatura na Vindi acumulando os produtos num mesmo plano. É um comportamento incorreto. Para mais detalhes, ver #59 .

## Solução proposta
Alteração no fluxo de pagamento prevendo o uso de assinaturas do tipo "subscription_variation", que ainda não estavam sendo tratadas em trechos do código.

## Como testar
Tentar realizar a compra de duas assinaturas que são variações do mesmo produto no Woocommerce, e cujos planos sejam diferentes. O fluxo de pagamento / compra deve ocorrer normalmente e duas assinaturas separadas devem ser criadas na Vindi.

Closes #59 