### PR TITLE
Adiciona função para verificar se o Memberships está ativo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.6
 WC requires at least: 3.0.0
 WC tested up to: 4.9.0
 Requires PHP: 5.6
-Stable Tag: 1.1.2
+Stable Tag: 1.1.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.3 - 18/03/2021 =
+- Lançamento da versão de patch.
+- **Correção**: Foi corrigido um comportamento que impedia a atualização correta de status de assinaturas caso o plugin WooCommerce Memberships estivesse ativo
+
+
 = 1.1.2 - 15/03/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento na compra de assinaturas variantes do mesmo produto (ex.: tamanho P e G), cujos planos/periodicidades são diferentes (ex.: mensal e anual). Essas assinaturas serão criadas separadamente na Plataforma Vindi.

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.2');
+define('VINDI_VERSION', '1.1.3');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/validators/Dependencies.php
+++ b/src/validators/Dependencies.php
@@ -57,6 +57,15 @@ class VindiDependencies
         );
     }
 
+    public static function is_wc_memberships_active()
+    {
+        $wc_memberships = 'woocommerce-memberships/woocommerce-memberships.php';
+        if (is_plugin_active($wc_memberships)) {
+            return true;
+        }
+        return false;
+    }
+
     /**
     * Check required critical dependencies
     *

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.2
+ * Version: 1.1.3
  * Requires at least: 4.4
  * Tested up to: 5.6
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Foi adicionado um check da dependência do WooCommerce Memberships

## Motivação
Na issue #73, foi reportado um problema que comprometia o funcionamento entre Vindi e Memberships pela falta da validação no código.

## Solução proposta
Adicionar a validação.

## Como testar
Com as dependências instaladas:

1. Criar um produto de assinatura (simple subscription)
2. Comprar
3. Cancelar na Vindi
4. No painel do WooCommerce, verificar se o status da assinatura está em `Pending Cancellation`