### PR TITLE
Corrige exibição de boleto no checkout

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.6
 WC requires at least: 3.0.0
 WC tested up to: 4.9.0
 Requires PHP: 5.6
-Stable Tag: 1.1.3
+Stable Tag: 1.1.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.4 - 01/04/2021 =
+- Lançamento da versão de patch.
+- **Correção**: Foi corrigido o comportamento que não exibia o link para download do boleto bancário no checkout.
+
+
 = 1.1.3 - 19/03/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento de atualização de status das assinaturas caso o plugin WooCommerce Memberships esteja ativo.
@@ -106,7 +111,7 @@ Os valores referentes a fretes serão enviados especificamente por assinaturas;
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.1.3 - 19/03/2021 =
+= 1.1.4 - 01/04/2021 =
 Patch de correções para o plugin Vindi
 
 == License ==

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ Os valores referentes a fretes serão enviados especificamente por assinaturas;
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.1.4 - 01/04/2021 =
+= 1.1.4 - 05/04/2021 =
 Patch de correções para o plugin Vindi
 
 == License ==

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
-= 1.1.4 - 01/04/2021 =
+= 1.1.4 - 05/04/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento que impossibilitava a visualização de boletos no checkout na adesão de uma ou mais assinaturas.
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 == Changelog ==
 = 1.1.4 - 01/04/2021 =
 - Lançamento da versão de patch.
-- **Correção**: Foi corrigido o comportamento que não exibia o link para download do boleto bancário no checkout.
+- **Correção**: Foi corrigido o comportamento que impossibilitava a visualização de boletos no checkout na adesão de uma ou mais assinaturas.
 
 
 = 1.1.3 - 19/03/2021 =

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -132,7 +132,8 @@ class VindiBankSlipGateway extends VindiPaymentGateway
             $vindi_order = get_post_meta($order_id, 'vindi_order', true);
             $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
             $this->vindi_settings->get_template(
-                'bankslip-download.html.php', compact('vindi_order', 'order_to_iterate')
+                'bankslip-download.html.php',
+                compact('vindi_order', 'order_to_iterate')
             );
       }
   }

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -96,9 +96,9 @@ class VindiBankSlipGateway extends VindiPaymentGateway
 
   public function bank_slip_quantity_to_render($order)
   {
-      if (is_null($order[0])) {
+        if (is_null($order[0])) {
             return $order;
-      }
+        }
 
         return $order[0];
   }

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -95,6 +95,12 @@ class VindiBankSlipGateway extends VindiPaymentGateway
   }
 
     public function bank_slip_quantity_to_render($order)
+    # Essa função é responsável
+    # por verificar se a compra que está sendo feita
+    # se trata de apenas uma subscription ou mais
+    # se for uma subscription, o $order[0] não existirá
+    # issue: https://github.com/vindi/vindi-woocommerce/issues/75
+
     {
         if (is_null($order[0])) {
             return $order;

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -94,14 +94,14 @@ class VindiBankSlipGateway extends VindiPaymentGateway
     );
   }
 
-  public function bank_slip_quantity_to_render($order)
-  {
+    public function bank_slip_quantity_to_render($order)
+    {
         if (is_null($order[0])) {
             return $order;
         }
 
         return $order[0];
-  }
+    }
 
   public function payment_fields()
   {
@@ -131,7 +131,9 @@ class VindiBankSlipGateway extends VindiPaymentGateway
       if ($order->get_payment_method() == 'vindi-bank-slip') {
             $vindi_order = get_post_meta($order_id, 'vindi_order', true);
             $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
-            $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
+            $this->vindi_settings->get_template(
+                'bankslip-download.html.php', compact('vindi_order', 'order_to_iterate')
+            );
       }
   }
 

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -94,13 +94,12 @@ class VindiBankSlipGateway extends VindiPaymentGateway
     );
   }
 
-    public function bank_slip_quantity_to_render($order)
     # Essa função é responsável
     # por verificar se a compra que está sendo feita
     # se trata de apenas uma subscription ou mais
     # se for uma subscription, o $order[0] não existirá
     # issue: https://github.com/vindi/vindi-woocommerce/issues/75
-
+    public function bank_slip_quantity_to_render($order)
     {
         if (is_null($order[0])) {
             return $order;

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -96,11 +96,11 @@ class VindiBankSlipGateway extends VindiPaymentGateway
 
   public function bank_slip_quantity_to_render($order)
   {
-    if (is_null($order[0])) {
-      return $order;
-    }
-    
-    return $order[0];
+      if (is_null($order[0])) {
+          return $order;
+      }
+
+      return $order[0];
   }
 
   public function payment_fields()
@@ -127,12 +127,12 @@ class VindiBankSlipGateway extends VindiPaymentGateway
 
   public function thank_you_page($order_id)
   {
-    $order = wc_get_order($order_id);
-    if ($order->get_payment_method() == 'vindi-bank-slip') {
-      $vindi_order = get_post_meta($order_id, 'vindi_order', true);
-      $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
-      $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
-    }
+      $order = wc_get_order($order_id);
+      if ($order->get_payment_method() == 'vindi-bank-slip') {
+          $vindi_order = get_post_meta($order_id, 'vindi_order', true);
+          $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
+          $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
+      }
   }
 
   public function show_bank_slip_download($order_id) {

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -94,11 +94,9 @@ class VindiBankSlipGateway extends VindiPaymentGateway
     );
   }
 
-    # Essa função é responsável
-    # por verificar se a compra que está sendo feita
-    # se trata de apenas uma subscription ou mais
-    # se for uma subscription, o $order[0] não existirá
-    # issue: https://github.com/vindi/vindi-woocommerce/issues/75
+    # Essa função é responsável por verificar a compra que está sendo feita
+    # No caso de uma assinatura única, o $order[0] não existirá e retornará ela mesmo
+    # Issue: https://github.com/vindi/vindi-woocommerce/issues/75
     public function bank_slip_quantity_to_render($order)
     {
         if (is_null($order[0])) {

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -97,10 +97,10 @@ class VindiBankSlipGateway extends VindiPaymentGateway
   public function bank_slip_quantity_to_render($order)
   {
       if (is_null($order[0])) {
-          return $order;
+            return $order;
       }
 
-      return $order[0];
+        return $order[0];
   }
 
   public function payment_fields()
@@ -129,9 +129,9 @@ class VindiBankSlipGateway extends VindiPaymentGateway
   {
       $order = wc_get_order($order_id);
       if ($order->get_payment_method() == 'vindi-bank-slip') {
-          $vindi_order = get_post_meta($order_id, 'vindi_order', true);
-          $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
-          $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
+            $vindi_order = get_post_meta($order_id, 'vindi_order', true);
+            $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
+            $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
       }
   }
 

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -94,6 +94,15 @@ class VindiBankSlipGateway extends VindiPaymentGateway
     );
   }
 
+  public function bank_slip_quantity_to_render($order)
+  {
+    if (is_null($order[0])) {
+      return $order;
+    }
+    
+    return $order[0];
+  }
+
   public function payment_fields()
   {
     $user_country = $this->get_country_code();
@@ -121,7 +130,8 @@ class VindiBankSlipGateway extends VindiPaymentGateway
     $order = wc_get_order($order_id);
     if ($order->get_payment_method() == 'vindi-bank-slip') {
       $vindi_order = get_post_meta($order_id, 'vindi_order', true);
-      $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order'));
+      $order_to_iterate = $this->bank_slip_quantity_to_render($vindi_order);
+      $this->vindi_settings->get_template('bankslip-download.html.php', compact('vindi_order', 'order_to_iterate'));
     }
   }
 

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,5 +1,4 @@
-<?php if (!defined('ABSPATH')) exit; ?>
-<?php
+<?php if (!defined('ABSPATH')) exit;
 function bank_slip_quantity_to_render($order)
 {
     if (is_null($order[0])) {

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -47,7 +47,7 @@ function bank_slip_quantity_to_render($order)
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>
-     <?php endforeach; ?>
+    <?php endforeach; ?>
 		</div>
 	</div>
 <?php endif; ?>

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,11 +1,11 @@
 <?php
 function bank_slip_quantity_to_render($order)
 {
-  if (is_null($order[0])) {
-    return $order;		
-  }
+    if (is_null($order[0])) {
+      return $order;		
+    }
 
-  return $order[0];
+    return $order[0];
 }
 ?>
 <?php if (!defined('ABSPATH')) exit; ?>

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,11 +1,12 @@
 <?php
-  function bank_slip_quantity_to_render($order) {
-    if (is_null($order[0])) {
-      return $order;		
-    }
-
-    return $order[0];
+function bank_slip_quantity_to_render($order)
+{
+  if (is_null($order[0])) {
+    return $order;		
   }
+
+  return $order[0];
+}
 ?>
 <?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,12 +1,11 @@
 <?php
-function bank_slip_quantity_to_render($order)
-{
-	if (is_null($order[0])) {
-		return $order;		
-	} else {
-		return $order[0];
-	}
-}
+  function bank_slip_quantity_to_render($order) {
+    if (is_null($order[0])) {
+      return $order;		
+    }
+
+    return $order[0];
+  }
 ?>
 <?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,13 +1,3 @@
-<?php
-function bank_slip_quantity_to_render($order)
-{
-    if (is_null($order[0])) {
-        return $order;
-    }
-
-    return $order[0];
-}
-?>
 <?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
@@ -23,7 +13,7 @@ function bank_slip_quantity_to_render($order)
 			</div>
 		</div>
 		<div class="bankslips">
-    <?php foreach (bank_slip_quantity_to_render($vindi_order) as $subscription) : ?>
+    <?php foreach ($order_to_iterate as $subscription) : ?>
 				<?php if (is_array($subscription) && array_key_exists('product', $subscription) && !in_array($subscription['bill']['status'], array('paid', 'canceled'))): ?>
 						<div class="bankslip">
 							<span class="product_title">

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,14 +1,14 @@
+<?php if (!defined('ABSPATH')) exit; ?>
 <?php
 function bank_slip_quantity_to_render($order)
 {
     if (is_null($order[0])) {
-      return $order;
+        return $order;
     }
 
     return $order[0];
 }
 ?>
-<?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
 		<div class="info_message">
@@ -47,7 +47,7 @@ function bank_slip_quantity_to_render($order)
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>
-			<?php endforeach; ?>
+    <?php endforeach; ?>
 		</div>
 	</div>
 <?php endif; ?>

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -2,7 +2,7 @@
 function bank_slip_quantity_to_render($order)
 {
     if (is_null($order[0])) {
-      return $order;		
+      return $order;
     }
 
     return $order[0];
@@ -23,7 +23,7 @@ function bank_slip_quantity_to_render($order)
 			</div>
 		</div>
 		<div class="bankslips">
-			<?php foreach (bank_slip_quantity_to_render($vindi_order) as $subscription): ?>
+    <?php foreach (bank_slip_quantity_to_render($vindi_order) as $subscription) : ?>
 				<?php if (is_array($subscription) && array_key_exists('product', $subscription) && !in_array($subscription['bill']['status'], array('paid', 'canceled'))): ?>
 						<div class="bankslip">
 							<span class="product_title">

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,14 +1,16 @@
-<?php if (!defined('ABSPATH')) exit; ?>
 <?php
-function bank_slip_quantity_to_render($order)
-{
-    if (is_null($order[0])) {
-        return $order;
-    }
+if (! function_exists('bank_slip_quantity_to_render')) {
+  function bank_slip_quantity_to_render($order)
+  {
+      if (is_null($order[0])) {
+          return $order;
+      }
 
-    return $order[0];
+      return $order[0];
+  }
 }
 ?>
+<?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
 		<div class="info_message">

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,4 +1,4 @@
-<?php if (!defined('ABSPATH')) exit;
+<?php
 function bank_slip_quantity_to_render($order)
 {
     if (is_null($order[0])) {
@@ -8,6 +8,7 @@ function bank_slip_quantity_to_render($order)
     return $order[0];
 }
 ?>
+<?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
 		<div class="info_message">

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,3 +1,13 @@
+<?php
+function bank_slip_quantity_to_render($order)
+{
+	if (is_null($order[0])) {
+		return $order;		
+	} else {
+		return $order[0];
+	}
+}
+?>
 <?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
@@ -13,7 +23,7 @@
 			</div>
 		</div>
 		<div class="bankslips">
-			<?php foreach ($vindi_order[0] as $subscription): ?>
+			<?php foreach (bank_slip_quantity_to_render($vindi_order) as $subscription): ?>
 				<?php if (is_array($subscription) && array_key_exists('product', $subscription) && !in_array($subscription['bill']['status'], array('paid', 'canceled'))): ?>
 						<div class="bankslip">
 							<span class="product_title">

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -1,16 +1,14 @@
+<?php if (!defined('ABSPATH')) exit; ?>
 <?php
-if (! function_exists('bank_slip_quantity_to_render')) {
-  function bank_slip_quantity_to_render($order)
-  {
-      if (is_null($order[0])) {
-          return $order;
-      }
+function bank_slip_quantity_to_render($order)
+{
+    if (is_null($order[0])) {
+        return $order;
+    }
 
-      return $order[0];
-  }
+    return $order[0];
 }
 ?>
-<?php if (!defined('ABSPATH')) exit; ?>
 <?php if (isset($vindi_order)): ?>
 	<div class="vindi_bankslip_listing">
 		<div class="info_message">
@@ -49,7 +47,7 @@ if (! function_exists('bank_slip_quantity_to_render')) {
 						<?php endif; ?>
 					<?php endforeach; ?>
 				<?php endif; ?>
-    <?php endforeach; ?>
+     <?php endforeach; ?>
 		</div>
 	</div>
 <?php endif; ?>

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.3');
+define('VINDI_VERSION', '1.1.4');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.3
+ * Version: 1.1.4
  * Requires at least: 4.4
  * Tested up to: 5.6
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Foi corrigido o comportamento que impossibilitava a visualização de boletos no checkout na adesão de uma ou mais assinaturas.

## Motivação
Foi reportado na issue https://github.com/vindi/vindi-woocommerce/issues/75 um problema na exibição de boletos no checkout. Isso estava ocorrendo pois a validação só previa compras para boletos 

## Solução proposta
Estou criando uma função que validará se a order que está sendo exibida no checkout é de uma ou mais assinaturas.

## Como testar
Realize a compra de **apenas uma assinatura** e verifique se no checkout é exibido o botão "Baixar boleto". Se sim, está funcionando
