### PR TITLE
Versionamento 1.1.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,9 +7,9 @@ Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança
 Author URI: https://vindi.com.br/ | https://mentores.com.br
 Author: Vindi | Mentores Digital
 Requires at least: 4.4
-Tested up to: 5.6
+Tested up to: 5.7
 WC requires at least: 3.0.0
-WC tested up to: 4.9.0
+WC tested up to: 5.1.0
 Requires PHP: 5.6
 Stable Tag: 1.1.5
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -53,7 +53,7 @@ Lista de bandeiras aceitas:
 - Diners Club
 - JCB
 
-**Importante**: Caso não tenha alguma dessas bandeiras habilitadas na plataforma Vindi e haja uma tentativa de compra, não será possível criar o cartão de crédito, gerando um erro em tela.
+**Importante**: Caso alguma dessas bandeiras não esteja habilitada na plataforma Vindi e haja uma tentativa de compra, não será possível criar o perfil de pagamento, impossibilitando a conclusão da compra.
 
 
 = 1.1.4 - 05/04/2021 =

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.6
 WC requires at least: 3.0.0
 WC tested up to: 4.9.0
 Requires PHP: 5.6
-Stable Tag: 1.1.4
+Stable Tag: 1.1.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,23 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.5 - 08/04/2021 =
+- Lançamento da versão de patch.
+- **Correção**: Foi corrigido o comportamento que impossibilitava a visualização de boletos na página minha conta.
+- **Adição**: Foi adicionado o suporte a novas bandeiras de cartão de crédito.
+Lista de bandeiras aceitas:
+- Hipercard
+- Elo
+- American Express
+- Visa
+- Mastercard
+- Discover
+- Diners Club
+- JCB
+
+**Importante**: Caso não tenha alguma dessas bandeiras habilitadas na plataforma Vindi e haja uma tentativa de compra, não será possível criar o cartão de crédito, gerando um erro em tela.
+
+
 = 1.1.4 - 05/04/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento que impossibilitava a visualização de boletos no checkout na adesão de uma ou mais assinaturas.
@@ -111,7 +128,7 @@ Os valores referentes a fretes serão enviados especificamente por assinaturas;
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.1.4 - 05/04/2021 =
+= 1.1.5 - 08/04/2021 =
 Patch de correções para o plugin Vindi
 
 == License ==

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.4');
+define('VINDI_VERSION', '1.1.5');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.4
+ * Version: 1.1.5
  * Requires at least: 4.4
  * Tested up to: 5.6
  * WC requires at least: 3.0.0

--- a/vindi.php
+++ b/vindi.php
@@ -8,9 +8,9 @@
  * Author URI: https://www.vindi.com.br
  * Version: 1.1.5
  * Requires at least: 4.4
- * Tested up to: 5.6
+ * Tested up to: 5.7
  * WC requires at least: 3.0.0
- * WC tested up to: 4.9.0
+ * WC tested up to: 5.1.0
  * Text Domain: vindi-payment-gateway
  *
  * Domain Path: ./src/languages/


### PR DESCRIPTION
## O que mudou
- **Correção**: Foi corrigido o comportamento que impossibilitava a visualização de boletos na página minha conta.
- **Adição**: Foi adicionado o suporte a novas bandeiras de cartão de crédito.
Lista de bandeiras aceitas:
- Hipercard
- Elo
- American Express
- Visa
- Mastercard
- Discover
- Diners Club
- JCB

**Importante**: Caso alguma dessas bandeiras não esteja habilitada na plataforma Vindi e haja uma tentativa de compra, não será possível criar o perfil de pagamento, impossibilitando a conclusão da compra.
