### PR TITLE
Corrige envio de frete para faturas avulsas

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -649,18 +649,17 @@ class VindiPaymentProcessor
         }
 
         foreach ($order_items as $order_item) {
-            $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
             $product = $order_item->get_product();
 
             if ($product->needs_shipping()) {
                 $item = $this->routes->findOrCreateProduct(
-                    sprintf("Frete (%s)", $wc_subscription->get_shipping_method()),
-                    sanitize_title($wc_subscription->get_shipping_method())
+                    sprintf("Frete (%s)", $shipping_method),
+                    sanitize_title($shipping_method)
                 );
                 $shipping_item = array(
                     'type' => 'shipping',
                     'vindi_id' => $item['id'],
-                    'price' => $wc_subscription->get_total_shipping(),
+                    'price' => $this->order->get_total_shipping(),
                     'qty' => 1,
                 );
             }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -657,7 +657,6 @@ class VindiPaymentProcessor
             $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
 
             $product = $order_item->get_product();
-
             if ($product->needs_shipping()) {
                 $item = $this->routes->findOrCreateProduct(
                     sprintf("Frete (%s)", $shipping_method),

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -650,13 +650,12 @@ class VindiPaymentProcessor
 
         foreach ($order_items as $order_item) {
             $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
+            $product = $order_item->get_product();
             $shipping_method = $this->is_subscription_type($product) ?
             $wc_subscription->get_shipping_method() : $shipping_method;
-
             $get_total_shipping = $this->is_subscription_type($product) ?
             $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
 
-            $product = $order_item->get_product();
             if ($product->needs_shipping()) {
                 $item = $this->routes->findOrCreateProduct(
                     sprintf("Frete (%s)", $shipping_method),

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -650,8 +650,12 @@ class VindiPaymentProcessor
 
         foreach ($order_items as $order_item) {
             $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
-            $shipping_method = $this->is_subscription_type($product) ? $wc_subscription->get_shipping_method() : $shipping_method;
-            $get_total_shipping = $this->is_subscription_type($product) ? $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
+            $shipping_method = $this->is_subscription_type($product) ?
+            $wc_subscription->get_shipping_method() : $shipping_method;
+
+            $get_total_shipping = $this->is_subscription_type($product) ?
+            $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
+
             $product = $order_item->get_product();
 
             if ($product->needs_shipping()) {

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -649,6 +649,9 @@ class VindiPaymentProcessor
         }
 
         foreach ($order_items as $order_item) {
+            $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
+            $shipping_method = $this->is_subscription_type($product) ? $wc_subscription->get_shipping_method() : $shipping_method;
+            $get_total_shipping = $this->is_subscription_type($product) ? $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
             $product = $order_item->get_product();
 
             if ($product->needs_shipping()) {
@@ -659,7 +662,7 @@ class VindiPaymentProcessor
                 $shipping_item = array(
                     'type' => 'shipping',
                     'vindi_id' => $item['id'],
-                    'price' => $this->order->get_total_shipping(),
+                    'price' => $get_total_shipping,
                     'qty' => 1,
                 );
             }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -643,6 +643,7 @@ class VindiPaymentProcessor
     {
         $shipping_item = [];
         $shipping_method = $this->order->get_shipping_method();
+        $get_total_shipping = $this->order->get_total_shipping();
 
         if (empty($shipping_method)) {
             return $shipping_item;
@@ -655,8 +656,6 @@ class VindiPaymentProcessor
             if ($this->is_subscription_type($product)) {
                 $shipping_method = $wc_subscription->get_shipping_method();
                 $get_total_shipping = $wc_subscription->get_total_shipping();
-            } else {
-                $get_total_shipping = $this->order->get_total_shipping();
             }
 
             if ($product->needs_shipping()) {

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -651,16 +651,15 @@ class VindiPaymentProcessor
         foreach ($order_items as $order_item) {
             $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
             $product = $order_item->get_product();
+
             $shipping_method = $this->is_subscription_type($product) ?
             $wc_subscription->get_shipping_method() : $shipping_method;
+
             $get_total_shipping = $this->is_subscription_type($product) ?
             $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
 
             if ($product->needs_shipping()) {
-                $item = $this->routes->findOrCreateProduct(
-                    sprintf("Frete (%s)", $shipping_method),
-                    sanitize_title($shipping_method)
-                );
+                $item = create_shipping_product($shipping_method);
                 $shipping_item = array(
                     'type' => 'shipping',
                     'vindi_id' => $item['id'],
@@ -670,6 +669,14 @@ class VindiPaymentProcessor
             }
         }
         return $shipping_item;
+    }
+    
+    private function create_shipping_product($shipping_method)
+    {
+        $this->routes->findOrCreateProduct(
+            sprintf("Frete (%s)", $shipping_method),
+            sanitize_title($shipping_method)
+        );
     }
 
     /**

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -652,14 +652,15 @@ class VindiPaymentProcessor
             $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
             $product = $order_item->get_product();
 
-            $shipping_method = $this->is_subscription_type($product) ?
-            $wc_subscription->get_shipping_method() : $shipping_method;
-
-            $get_total_shipping = $this->is_subscription_type($product) ?
-            $wc_subscription->get_total_shipping() : $this->order->get_total_shipping();
+            if ($this->is_subscription_type($product)) {
+                $shipping_method = $wc_subscription->get_shipping_method();
+                $get_total_shipping = $wc_subscription->get_total_shipping();
+            } else {
+                $get_total_shipping = $this->order->get_total_shipping();
+            }
 
             if ($product->needs_shipping()) {
-                $item = create_shipping_product($shipping_method);
+                $item = $this->create_shipping_product($shipping_method);
                 $shipping_item = array(
                     'type' => 'shipping',
                     'vindi_id' => $item['id'],


### PR DESCRIPTION
## O que mudou
Foi corrigido o comportamento que impediam que compras avulsas com frete pudessem ser realizadas.

## Motivação
Na issue #83, foi reportado um `Internal Server Error` ao finalizar compras avulsas.

## Solução proposta
Estamos corrigindo esse comportamento, pois anteriormente a function `VindiHelpers::get_matching_subscription($this->order, $order_item);` estava retornando `null` para compras avulsas e, por conta disso, estava ocorrendo uma exceção na chamada da function `get_shipping_method()`.

## Como testar
- Crie um produto simples no WooCommerce
- Configure um frete para esse produto
- Realize a compra e veja se foi feita normalmente e o produto frete foi criado na Vindi como esperado