### PR TITLE
Ajusta função que cria o produto de frete na Vindi

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -673,10 +673,12 @@ class VindiPaymentProcessor
     
     private function create_shipping_product($shipping_method)
     {
-        $this->routes->findOrCreateProduct(
+        $product = $this->routes->findOrCreateProduct(
             sprintf("Frete (%s)", $shipping_method),
             sanitize_title($shipping_method)
         );
+        
+        return $product;
     }
 
     /**

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -673,12 +673,10 @@ class VindiPaymentProcessor
     
     private function create_shipping_product($shipping_method)
     {
-        $product = $this->routes->findOrCreateProduct(
+        return $this->routes->findOrCreateProduct(
             sprintf("Frete (%s)", $shipping_method),
             sanitize_title($shipping_method)
         );
-        
-        return $product;
     }
 
     /**


### PR DESCRIPTION
## O que mudou
Foi corrigido um comportamento que estava impedindo o frete a ser enviado para a Vindi

## Motivação
Não estavam sendo enviadas requisições para pagamentos com frete para a Vindi após o merge do PR #84 

## Solução proposta
Ajuste na function

## Como testar
- Realize uma compra com frete
- Certifique-se de que o produto "Frete" foi criado na Vindi