### PR TITLE
Adicionando o tipo de cupom de desconto "percentual recorrente" (Recurring Product % Discount)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,8 @@ engines:
   phpmd:
     enabled: true
     checks:
+      StaticAccess:
+        enabled: false
       UnusedPrivateMethod:
         enabled: false
       Controversial/CamelCaseMethodName:

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.7
 WC requires at least: 3.0.0
 WC tested up to: 5.1.0
 Requires PHP: 5.6
-Stable Tag: 1.1.6
+Stable Tag: 1.1.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.7 - 05/05/2021 =
+- Lançamento da versão de minor.
+- **Adição**: Foi adicionado o tipo de cupom de desconto Recurring Product % Discount (nativo do Woocommerce Subscriptions) integrado com a API da Vindi.
+
+
 = 1.1.6 - 16/04/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento que impedia que compras avulsas com frete pudessem ser realizadas.
@@ -133,8 +138,8 @@ Os valores referentes a fretes serão enviados especificamente por assinaturas;
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.1.6 - 16/04/2021 =
-Patch de correções para o plugin Vindi
+= 1.1.7 - 05/05/2021 =
+Minor upgrade com nova funcionalidade para o plugin Vindi
 
 == License ==
 

--- a/src/assets/js/admin.js
+++ b/src/assets/js/admin.js
@@ -35,13 +35,16 @@ jQuery(document).ready(function($) {
     }
   });
 
-  $wcs_number_payments.on('change', function() {
-    var val = $(this).val();
-    var regex = new RegExp(/^(1|2|3|4|5|6|7|8|9|10|11|12)$/);
-    if (val != '' && !regex.test(val)) {
-      $(this).val('');
-    }
-  });
+  if ($wcs_number_payments)
+  {
+    $wcs_number_payments.on('change', function() {
+      var val = $(this).val();
+      var regex = new RegExp(/^(1|2|3|4|5|6|7|8|9|10|11|12)$/);
+      if (val != '' && !regex.test(val)) {
+        $(this).val('');
+      }
+    });
+  }
   
   /**
    * Subscription coupon actions.
@@ -67,16 +70,25 @@ jQuery(document).ready(function($) {
 
       switch (discount_type) {
         case 'recurring_percent':
-          $cycles_field.hide();
-          $cycles_input.val('0');
+          if ($cycles_field.is(':visible'))
+          {
+            $cycles_field.hide();
+            $cycles_input.val('0');
+          }
           break;
         case 'fixed_cart':
-          $cycles_field.hide();
-          $cycles_input.val('1');
+          if ($cycles_field.is(':visible'))
+          {
+            $cycles_field.hide();
+            $cycles_input.val('1');
+          }
           break;
         default:
-          $cycles_field.show();
-          $cycles_input.val('0');
+          if ($cycles_field.is(':hidden'))
+          {
+            $cycles_field.show();
+            $cycles_input.val('0');
+          }
           break;
       }
     },

--- a/src/assets/js/admin.js
+++ b/src/assets/js/admin.js
@@ -7,6 +7,8 @@ jQuery(document).ready(function($) {
     $cycles_field = $(cycles_field);
   var interest_rate_input = document.querySelector('#woocommerce_vindi-credit-card_interest_rate'),
     $interest_rate_input = $(interest_rate_input);
+  var wcs_number_payments = document.querySelector('#wcs_number_payments'),
+    $wcs_number_payments = $(wcs_number_payments);
   
   $interest_rate_input.mask('##0.00%', {
     reverse: true,
@@ -33,6 +35,14 @@ jQuery(document).ready(function($) {
     }
   });
 
+  $wcs_number_payments.on('change', function() {
+    var val = $(this).val();
+    var regex = new RegExp(/^(1|2|3|4|5|6|7|8|9|10|11|12)$/);
+    if (val != '' && !regex.test(val)) {
+      $(this).val('');
+    }
+  });
+  
   /**
    * Subscription coupon actions.
    * @type {{init: function, type_options: function, move_field: function}}
@@ -56,6 +66,10 @@ jQuery(document).ready(function($) {
       var discount_type = $(this).val();
 
       switch (discount_type) {
+        case 'recurring_percent':
+          $cycles_field.hide();
+          $cycles_input.val('0');
+          break;
         case 'fixed_cart':
           $cycles_field.hide();
           $cycles_input.val('1');

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -16,28 +16,32 @@ class CouponsMetaBox {
 	 */
   public static function output( $coupon_id, $coupon )
   {
-		woocommerce_wp_select(
-			array(
-				'id'      => 'cycle_count',
-				'label'   => __( 'Número de ciclos do cupom', VINDI ),
-				'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
-				'options' => array(
-					'0'  => 'Todos os ciclos',
-					'1'  => '1 ciclo',
-					'2'  => '2 ciclos',
-					'3'  => '3 ciclos',
-					'4'  => '4 ciclos',
-					'5'  => '5 ciclos',
-					'6'  => '6 ciclos',
-					'7'  => '7 ciclos',
-					'8'  => '8 ciclos',
-					'9'  => '9 ciclos',
-					'10' => '10 ciclos',
-					'11' => '11 ciclos',
-					'12' => '12 ciclos',
-				),
-			)
+		$arr = array(
+			'id'      => 'cycle_count',
+			'label'   => __( 'Número de ciclos do cupom', VINDI ),
+			'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
+			'options' => array(
+				'0'  => 'Todos os ciclos',
+				'1'  => '1 ciclo',
+				'2'  => '2 ciclos',
+				'3'  => '3 ciclos',
+				'4'  => '4 ciclos',
+				'5'  => '5 ciclos',
+				'6'  => '6 ciclos',
+				'7'  => '7 ciclos',
+				'8'  => '8 ciclos',
+				'9'  => '9 ciclos',
+				'10' => '10 ciclos',
+				'11' => '11 ciclos',
+				'12' => '12 ciclos',
+			),
 		);
+
+		if ($coupon->get_discount_type() == 'recurring_percent') {
+			array_push($arr, 'class', 'hidden');
+		}
+
+		woocommerce_wp_select($arr);
   }
 
   /**
@@ -71,8 +75,7 @@ class CouponsMetaBox {
 			array(
 				'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
 				'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
-				'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' ),
-				'recurring_percent'   => __( 'Recurring Product % Discount', 'woocommerce-subscriptions' ),
+				'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
 			)
 		);
   }

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -53,7 +53,7 @@ class CouponsMetaBox {
     public static function save($post_id, $post)
     {
         // Check the nonce (again).
-        if (empty( VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce'])) || 
+        if (empty(VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce'])) ||
             !wp_verify_nonce(VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce']), 'woocommerce_save_data')) {
             return;
         }

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -13,7 +13,7 @@ class CouponsMetaBox {
      * Output the metabox.
      *
      * @param int $coupon_id
-	 * @param WC_Coupon $coupon
+     * @param WC_Coupon $coupon
      */
     public static function output($coupon_id, $coupon)
     {

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -14,12 +14,12 @@ class CouponsMetaBox {
      *
      * @param WP_Post $post
      */
-    public static function output( $coupon_id, $coupon )
+    public static function output($coupon_id, $coupon)
     {
         $arr = array(
             'id'      => 'cycle_count',
-            'label'   => __( 'Número de ciclos do cupom', VINDI ),
-            'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
+            'label'   => __('Número de ciclos do cupom', VINDI),
+            'value'   => get_post_meta($coupon_id, 'cycle_count')[0],
             'options' => array(
               '0'  => 'Todos os ciclos',
               '1'  => '1 ciclo',
@@ -53,11 +53,12 @@ class CouponsMetaBox {
     public static function save($post_id, $post)
     {
         // Check the nonce (again).
-        if ( empty( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']) ) || ! wp_verify_nonce( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data' ) ) {
+        if (empty( VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce'])) || 
+            !wp_verify_nonce(VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce']), 'woocommerce_save_data')) {
             return;
         }
-        $coupon = new WC_Coupon( $post_id );
-        $coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
+        $coupon = new WC_Coupon($post_id);
+        $coupon->update_meta_data('cycle_count', intval(filter_var($post['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
         $coupon->save();
     }
 

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -9,74 +9,74 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class CouponsMetaBox {
 
-  /**
-   * Output the metabox.
-   *
-   * @param WP_Post $post
-   */
-  public static function output( $coupon_id, $coupon )
-  {
-      $arr = array(
-          'id'      => 'cycle_count',
-          'label'   => __( 'Número de ciclos do cupom', VINDI ),
-          'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
-          'options' => array(
-            '0'  => 'Todos os ciclos',
-            '1'  => '1 ciclo',
-            '2'  => '2 ciclos',
-            '3'  => '3 ciclos',
-            '4'  => '4 ciclos',
-            '5'  => '5 ciclos',
-            '6'  => '6 ciclos',
-            '7'  => '7 ciclos',
-            '8'  => '8 ciclos',
-            '9'  => '9 ciclos',
-            '10' => '10 ciclos',
-            '11' => '11 ciclos',
-            '12' => '12 ciclos',
-          ),
-      );
+    /**
+     * Output the metabox.
+     *
+     * @param WP_Post $post
+     */
+    public static function output( $coupon_id, $coupon )
+    {
+        $arr = array(
+            'id'      => 'cycle_count',
+            'label'   => __( 'Número de ciclos do cupom', VINDI ),
+            'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
+            'options' => array(
+              '0'  => 'Todos os ciclos',
+              '1'  => '1 ciclo',
+              '2'  => '2 ciclos',
+              '3'  => '3 ciclos',
+              '4'  => '4 ciclos',
+              '5'  => '5 ciclos',
+              '6'  => '6 ciclos',
+              '7'  => '7 ciclos',
+              '8'  => '8 ciclos',
+              '9'  => '9 ciclos',
+              '10' => '10 ciclos',
+              '11' => '11 ciclos',
+              '12' => '12 ciclos',
+            ),
+        );
 
-      if ($coupon->get_discount_type() == 'recurring_percent') {
-          array_push($arr, 'class', 'hidden');
-      }
+        if ($coupon->get_discount_type() == 'recurring_percent') {
+            array_push($arr, 'class', 'hidden');
+        }
 
-      woocommerce_wp_select($arr);
-  }
+        woocommerce_wp_select($arr);
+    }
 
-  /**
-	 * Save meta box custom fields data.
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $post
-	 */
-  public static function save($post_id, $post)
-  {
-      // Check the nonce (again).
-      if ( empty( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']) ) || ! wp_verify_nonce( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data' ) ) {
-          return;
-      }
-      $coupon = new WC_Coupon( $post_id );
-      $coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
-      $coupon->save();
-  }
+    /**
+     * Save meta box custom fields data.
+     *
+     * @param int     $post_id
+     * @param WP_Post $post
+     */
+    public static function save($post_id, $post)
+    {
+        // Check the nonce (again).
+        if ( empty( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']) ) || ! wp_verify_nonce( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data' ) ) {
+            return;
+        }
+        $coupon = new WC_Coupon( $post_id );
+        $coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
+        $coupon->save();
+    }
 
-  /**
-	 * Remove Woocommerce Subscriptions recurring discount options.
-	 * This is done to force the user to select a vindi cicle count discount
-	 *
-	 * @param int     $post_id
-	 * @param WP_Post $post
-	 */
-  public static function remove_ws_recurring_discount($discount_types)
-  {
-      return array_diff(
-          $discount_types,
-          array(
-            'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
-            'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
-            'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
-          )
-      );
-  }
+    /**
+     * Remove Woocommerce Subscriptions recurring discount options.
+     * This is done to force the user to select a vindi cicle count discount
+     *
+     * @param int     $post_id
+     * @param WP_Post $post
+     */
+    public static function remove_ws_recurring_discount($discount_types)
+    {
+        return array_diff(
+            $discount_types,
+            array(
+              'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
+              'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
+              'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
+            )
+        );
+    }
 }

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -9,39 +9,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class CouponsMetaBox {
 
-	/**
-	 * Output the metabox.
-	 *
-	 * @param WP_Post $post
-	 */
+  /**
+   * Output the metabox.
+   *
+   * @param WP_Post $post
+   */
   public static function output( $coupon_id, $coupon )
   {
-		$arr = array(
-			'id'      => 'cycle_count',
-			'label'   => __( 'Número de ciclos do cupom', VINDI ),
-			'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
-			'options' => array(
-				'0'  => 'Todos os ciclos',
-				'1'  => '1 ciclo',
-				'2'  => '2 ciclos',
-				'3'  => '3 ciclos',
-				'4'  => '4 ciclos',
-				'5'  => '5 ciclos',
-				'6'  => '6 ciclos',
-				'7'  => '7 ciclos',
-				'8'  => '8 ciclos',
-				'9'  => '9 ciclos',
-				'10' => '10 ciclos',
-				'11' => '11 ciclos',
-				'12' => '12 ciclos',
-			),
-		);
+      $arr = array(
+          'id'      => 'cycle_count',
+          'label'   => __( 'Número de ciclos do cupom', VINDI ),
+          'value'   => get_post_meta($coupon->get_id(), 'cycle_count')[0],
+          'options' => array(
+            '0'  => 'Todos os ciclos',
+            '1'  => '1 ciclo',
+            '2'  => '2 ciclos',
+            '3'  => '3 ciclos',
+            '4'  => '4 ciclos',
+            '5'  => '5 ciclos',
+            '6'  => '6 ciclos',
+            '7'  => '7 ciclos',
+            '8'  => '8 ciclos',
+            '9'  => '9 ciclos',
+            '10' => '10 ciclos',
+            '11' => '11 ciclos',
+            '12' => '12 ciclos',
+          ),
+      );
 
-		if ($coupon->get_discount_type() == 'recurring_percent') {
-			array_push($arr, 'class', 'hidden');
-		}
+      if ($coupon->get_discount_type() == 'recurring_percent') {
+          array_push($arr, 'class', 'hidden');
+      }
 
-		woocommerce_wp_select($arr);
+      woocommerce_wp_select($arr);
   }
 
   /**
@@ -52,13 +52,13 @@ class CouponsMetaBox {
 	 */
   public static function save($post_id, $post)
   {
-    // Check the nonce (again).
-		if ( empty( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']) ) || ! wp_verify_nonce( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data' ) ) {
-			return;
-		}
-		$coupon = new WC_Coupon( $post_id );
-		$coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
-		$coupon->save();
+      // Check the nonce (again).
+      if ( empty( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']) ) || ! wp_verify_nonce( VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data' ) ) {
+          return;
+      }
+      $coupon = new WC_Coupon( $post_id );
+      $coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
+      $coupon->save();
   }
 
   /**
@@ -70,13 +70,13 @@ class CouponsMetaBox {
 	 */
   public static function remove_ws_recurring_discount($discount_types)
   {
-    return array_diff(
-			$discount_types,
-			array(
-				'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
-				'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
-				'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
-			)
-		);
+      return array_diff(
+          $discount_types,
+          array(
+            'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
+            'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
+            'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
+          )
+      );
   }
 }

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -12,7 +12,8 @@ class CouponsMetaBox {
     /**
      * Output the metabox.
      *
-     * @param WP_Post $post
+     * @param int $coupon_id
+	 * @param WC_Coupon $coupon
      */
     public static function output($coupon_id, $coupon)
     {
@@ -53,12 +54,12 @@ class CouponsMetaBox {
     public static function save($post_id, $post)
     {
         // Check the nonce (again).
-        if (empty(VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce'])) ||
-            !wp_verify_nonce(VindiHelpers::sanitize_xss($post['woocommerce_meta_nonce']), 'woocommerce_save_data')) {
+        if (empty(VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce'])) ||
+            !wp_verify_nonce(VindiHelpers::sanitize_xss($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data')) {
             return;
         }
         $coupon = new WC_Coupon($post_id);
-        $coupon->update_meta_data('cycle_count', intval(filter_var($post['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
+        $coupon->update_meta_data('cycle_count', intval(filter_var($_POST['cycle_count'], FILTER_SANITIZE_NUMBER_INT)));
         $coupon->save();
     }
 
@@ -66,8 +67,7 @@ class CouponsMetaBox {
      * Remove Woocommerce Subscriptions recurring discount options.
      * This is done to force the user to select a vindi cicle count discount
      *
-     * @param int     $post_id
-     * @param WP_Post $post
+     * @param array $discount_types
      */
     public static function remove_ws_recurring_discount($discount_types)
     {

--- a/src/includes/admin/CouponsMetaBox.php
+++ b/src/includes/admin/CouponsMetaBox.php
@@ -73,9 +73,9 @@ class CouponsMetaBox {
         return array_diff(
             $discount_types,
             array(
-              'sign_up_fee'         => __( 'Sign Up Fee Discount', 'woocommerce-subscriptions' ),
-              'sign_up_fee_percent' => __( 'Sign Up Fee % Discount', 'woocommerce-subscriptions' ),
-              'recurring_fee'       => __( 'Recurring Product Discount', 'woocommerce-subscriptions' )
+              'sign_up_fee'         => __('Sign Up Fee Discount', 'woocommerce-subscriptions'),
+              'sign_up_fee_percent' => __('Sign Up Fee % Discount', 'woocommerce-subscriptions'),
+              'recurring_fee'       => __('Recurring Product Discount', 'woocommerce-subscriptions')
             )
         );
     }

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.6');
+define('VINDI_VERSION', '1.1.7');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -870,7 +870,7 @@ class VindiPaymentProcessor
         } elseif (strpos($discount_type, 'fixed') !== false) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $amount;
-        } elseif (strpos($discount_type, 'percent') !== false || 
+        } elseif (strpos($discount_type, 'percent') !== false ||
                   strpos($discount_type, 'recurring_percent') !== false) {
             $discount_item['discount_type'] = 'percentage';
             $discount_item['percentage'] = $amount;
@@ -902,14 +902,16 @@ class VindiPaymentProcessor
             return $cycle_count;
         };
         
-        if ($coupon->get_discount_type() != 'recurring_percent')
+        if ($coupon->get_discount_type() != 'recurring_percent') {
             $cycle_count = get_post_meta($coupon->id, 'cycle_count', true);
-        else
+        }
+        else {
             $cycle_count = WC_Subscriptions_Coupon::get_coupon_limit($coupon->id);
-
+        }
+        
         switch ($cycle_count) {
             case '0':
-                return null;
+                return null;    
             default:
                 return $get_plan_length($cycle_count, $plan_cycles);
         }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -870,7 +870,8 @@ class VindiPaymentProcessor
         } elseif (strpos($discount_type, 'fixed') !== false) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $amount;
-        } elseif (strpos($discount_type, 'percent') !== false) {
+        } elseif (strpos($discount_type, 'percent') !== false || 
+                  strpos($discount_type, 'recurring_percent') !== false) {
             $discount_item['discount_type'] = 'percentage';
             $discount_item['percentage'] = $amount;
         }
@@ -900,7 +901,11 @@ class VindiPaymentProcessor
             }
             return $cycle_count;
         };
-        $cycle_count = get_post_meta($coupon->id, 'cycle_count', true);
+        
+        if ($coupon->get_discount_type() != 'recurring_percent')
+            $cycle_count = get_post_meta($coupon->id, 'cycle_count', true);
+        else
+            $cycle_count = WC_Subscriptions_Coupon::get_coupon_limit($coupon->id);
 
         switch ($cycle_count) {
             case '0':

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -902,16 +902,15 @@ class VindiPaymentProcessor
             return $cycle_count;
         };
         
-        if ($coupon->get_discount_type() != 'recurring_percent') {
-            $cycle_count = get_post_meta($coupon->id, 'cycle_count', true);
-        }
-        else {
+        $cycle_count = get_post_meta($coupon->id, 'cycle_count', true);
+
+        if ($coupon->get_discount_type() == 'recurring_percent') {
             $cycle_count = WC_Subscriptions_Coupon::get_coupon_limit($coupon->id);
         }
-        
+
         switch ($cycle_count) {
             case '0':
-                return null;    
+                return null;
             default:
                 return $get_plan_length($cycle_count, $plan_cycles);
         }

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.6
+ * Version: 1.1.7
  * Requires at least: 4.4
  * Tested up to: 5.7
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Agora é possível utilizar o cupom de desconto percentual recorrente (_Recurring Product % Discount_), nativo do Woocommerce Subscriptions, que aplica desconto por "x" ciclos na assinatura. Os descontos são aplicados na assinatura da Vindi também.

## Motivação
Issue #89 
Na v2 do plugin, esse tipo de cupom de desconto foi substituído pelo tipo "_Percentage_" (percentual), porém não garante a visualização correta da aplicação recorrente dos descontos no admin do Wordpress. Um de nossos clientes reportou isso e então implementamos o tipo "_Recurring Product % Discount_", deixando correta a visualização dos dados tanto no admin do Wordpress como no painel da Vindi.

## Solução proposta
Habilitar a exibição desse tipo de cupom de desconto, garantir que as regras de preenchimento sejam cumpridas (vazio ou de 1-12), bem como ajustar a integração com a API da Vindi.

## Como testar

- [x] Cadastrar um cupom de desconto do tipo _Recurring Product % Discount_
- [x] Fazer uma compra de produto recorrente sem aplicar o cupom de desconto
- [x] Fazer uma compra de produto recorrente aplicando o cupom de desconto - observar a correta aplicação tanto do admin do Wordpress como no painel da Vindi.
- [x] Fazer uma compra de dois produtos recorrentes e aplicar o cupom de desconto - observar a correta aplicação tanto do admin do Wordpress como no painel da Vindi.

Closes #89 