### PR TITLE
Adiciona validação de labels para merge do PR

### DIFF
--- a/.github/workflows/label_checker.yml
+++ b/.github/workflows/label_checker.yml
@@ -1,0 +1,19 @@
+name: Label Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          all_of: ":white_check_mark:  Pronto para lançamento"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivação
Corremos o risco mergear alterações sem que haja o correto versionamento.

### Solução proposta
Adicionar uma validação se a label (✅ Pronto para lançamento) está adicionada ao PR impedindo o merge do mesmo.