### PR TITLE
Escapando se não houver formulário para o cartão de crédito

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,11 +7,11 @@ Tags: vindi, subscriptions, pagamento-recorrente, cobranca-recorrente, cobrança
 Author URI: https://vindi.com.br/ | https://mentores.com.br
 Author: Vindi | Mentores Digital
 Requires at least: 4.4
-Tested up to: 5.7
+Tested up to: 5.8.1
 WC requires at least: 3.0.0
-WC tested up to: 5.1.0
+WC tested up to: 5.7.0
 Requires PHP: 5.6
-Stable Tag: 1.1.7
+Stable Tag: 1.1.8
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.8 - 23/09/2021 =
+- Lançamento da versão de patch.
+- **Correção**: Foi corrigido o comportamento que exibia erros JS em páginas diferentes do checkout ou quando não possuiam a opção de método de pagamento Cartão de crédito.
+
+
 = 1.1.7 - 05/05/2021 =
 - Lançamento da versão de minor.
 - **Adição**: Foi adicionado o tipo de cupom de desconto Recurring Product % Discount (nativo do Woocommerce Subscriptions) integrado com a API da Vindi.

--- a/src/assets/js/frontend.js
+++ b/src/assets/js/frontend.js
@@ -1,6 +1,8 @@
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
   'use strict';
-  const vindi_cc_input = function() {
+  const vindi_cc_input = function () {
+    if (!document.getElementById('vindi_cc_form-container')) return;
+
     const name = document.getElementById('vindi_cc_name');
     const cardnumber = document.getElementById('vindi_cc_cardnumber');
     const expirationdate = document.getElementById('vindi_cc_expirationdate');
@@ -17,7 +19,7 @@ jQuery(document).ready(function($) {
       mask: [
         {
           mask: '0000 0000 0000 0000',
-          regex:'^(4011(78|79)|43(1274|8935)|45(1416|7393|763(1|2))|50(4175|6699|67[0-7][0-9]|9000)|50(9[0-9][0-9][0-9])|627780|63(6297|6368)|650(03([^4])|04([0-9])|05(0|1)|05([7-9])|06([0-9])|07([0-9])|08([0-9])|4([0-3][0-9]|8[5-9]|9[0-9])|5([0-9][0-9]|3[0-8])|9([0-6][0-9]|7[0-8])|7([0-2][0-9])|541|700|720|727|901)|65165([2-9])|6516([6-7][0-9])|65500([0-9])|6550([0-5][0-9])|655021|65505([6-7])|6516([8-9][0-9])|65170([0-4]))\\d{0,15}',
+          regex: '^(4011(78|79)|43(1274|8935)|45(1416|7393|763(1|2))|50(4175|6699|67[0-7][0-9]|9000)|50(9[0-9][0-9][0-9])|627780|63(6297|6368)|650(03([^4])|04([0-9])|05(0|1)|05([7-9])|06([0-9])|07([0-9])|08([0-9])|4([0-3][0-9]|8[5-9]|9[0-9])|5([0-9][0-9]|3[0-8])|9([0-6][0-9]|7[0-8])|7([0-2][0-9])|541|700|720|727|901)|65165([2-9])|6516([6-7][0-9])|65500([0-9])|6550([0-5][0-9])|655021|65505([6-7])|6516([8-9][0-9])|65170([0-4]))\\d{0,15}',
           cardtype: 'elo'
         },
         {
@@ -86,7 +88,7 @@ jQuery(document).ready(function($) {
           from: 0,
           to: 99
         },
-        MM:  {
+        MM: {
           mask: IMask.MaskedRange,
           from: 1,
           to: 12
@@ -130,7 +132,7 @@ jQuery(document).ready(function($) {
     //pop in the appropriate card icon when detected
     cardnumber_mask.on("accept", function () {
       let card_type = cardnumber_mask.masked.currentMask.cardtype;
-      
+
       switch (card_type) {
         case 'elo':
           ccicon.innerHTML = elo;
@@ -267,13 +269,13 @@ jQuery(document).ready(function($) {
     });
   }
 
-  jQuery(window).load(function() {
+  jQuery(window).load(function () {
     vindi_cc_input();
   });
   jQuery('.vindi-old-cc-data').hide();
-  jQuery('body').on('updated_checkout', function() {
+  jQuery('body').on('updated_checkout', function () {
     vindi_cc_input();
-    jQuery(".vindi-change-card").bind('click', function(){
+    jQuery(".vindi-change-card").bind('click', function () {
       jQuery('.vindi-old-cc-data').hide();
       jQuery('.vindi-old-cc-data').find('input').prop('disabled', true);
 
@@ -283,7 +285,7 @@ jQuery(document).ready(function($) {
       return false;
     });
 
-    if(jQuery('.vindi-old-cc-data').length) {
+    if (jQuery('.vindi-old-cc-data').length) {
       jQuery('.vindi-old-cc-data').show();
       jQuery('.vindi-old-cc-data').find('input').prop('disabled', false);
 

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.7');
+define('VINDI_VERSION', '1.1.8');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -6,11 +6,11 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.7
+ * Version: 1.1.8
  * Requires at least: 4.4
- * Tested up to: 5.7
+ * Tested up to: 5.8.1
  * WC requires at least: 3.0.0
- * WC tested up to: 5.1.0
+ * WC tested up to: 5.7.0
  * Text Domain: vindi-payment-gateway
  *
  * Domain Path: ./src/languages/


### PR DESCRIPTION
## O que mudou

Remoção do erro **"Cannot read property 'isContentEditable' of null"** nas telas dos sites com o plugin.

## Motivação

Resolves: #87 

Estão sendo exibidos erros de JS em todas as páginas do plugin da Vindi:

![image](https://user-images.githubusercontent.com/50752933/116306652-b8500500-a77b-11eb-805b-7cbe4c2f1262.png)

Isso está ocorrendo devido a um problema na biblioteca que utilizamos, o iMask.
## Solução proposta

Escapar a função caso não exista um formulário de cartão de crédito.

## Como testar

1. Baixe a versão desse PR e altere o plugin `Vindi WooCommerce 2`.
2. Analise a configuração que deve está tudo ok e acesse a tela do site
3. Valide que não exista mais o erro no console.

**Obs.: Criação de um ambiente de erro está contido como um comentário dentro da  issue**