### PR TITLE
Corrigindo seleção da div com a classe representando o formulário

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # Para mais informações, ver https://help.github.com/articles/about-codeowners/
 
 *                                 @vindi/suporte-tecnico
-readme.txt                        @laerte-guimaraes @luizdalcicovindi
-vindi.php                         @laerte-guimaraes @luizdalcicovindi
-src/utils/DefinitionVariables.php @laerte-guimaraes @luizdalcicovindi
+readme.txt                        @laerte-guimaraes
+vindi.php                         @laerte-guimaraes
+src/utils/DefinitionVariables.php @laerte-guimaraes

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.8.1
 WC requires at least: 3.0.0
 WC tested up to: 5.7.0
 Requires PHP: 5.6
-Stable Tag: 1.1.8
+Stable Tag: 1.1.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.9 - 04/10/2021 =
+- Lançamento da versão de patch.
+- **Correção**: Foi corrigido o comportamento que permitia inserir qualquer tipo de dado no campo referente a numeração do cartão no checkout.
+
+
 = 1.1.8 - 23/09/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento que exibia erros JS em páginas diferentes do checkout ou quando não possuiam a opção de método de pagamento Cartão de crédito.

--- a/src/assets/js/frontend.js
+++ b/src/assets/js/frontend.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function ($) {
   'use strict';
   const vindi_cc_input = function () {
-    if (!document.getElementById('vindi_cc_form-container')) return;
+    if (!document.querySelector('.vindi_cc_form-container')) return;
 
     const name = document.getElementById('vindi_cc_name');
     const cardnumber = document.getElementById('vindi_cc_cardnumber');

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.8');
+define('VINDI_VERSION', '1.1.9');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.8
+ * Version: 1.1.9
  * Requires at least: 4.4
  * Tested up to: 5.8.1
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Correção do seletor que busca o formulário de Cartão de Crédito na tela.

## Motivação

Resolves: #101 
Com a versão 1.1.8 foi constatado que a mesma removeu a restrição dos campos de preenchimento dos dados de cartão, permitindo preencher com qualquer informação.

## Solução proposta

Em análise, foi percebido que o seletor que busca o formulário estava buscando um `id` onde na div só existia uma atribuição na `class`, esse erro fazia com que mesmo a tela possuindo o formulário, o seletor não encontrava a `div` e não carregava as validações do número de cartões, máscara de expiração, entre os outros campos.

A solução foi altera o seletor para buscar a `class` (`vindi_cc_form-container`) ao invés do `id`;

```diff
-    if (!document.getElementById('vindi_cc_form-container')) return;
+    if (!document.querySelector('.vindi_cc_form-container')) return;
```
## Como testar

1. Baixe a versão desse PR e altere o plugin Vindi WooCommerce 2.
2. Analise a configuração que deve está tudo ok e acesse a tela do site
3. Valide que na tela de finalizar compra é possível digitar somente número de cartões válios.
![Screenshot from 2021-10-01 09-43-46](https://user-images.githubusercontent.com/15862643/135621411-42234d8c-bc0f-47e2-82fd-785e8330e46d.png)

