### PR TITLE
adiciona retrocompatibilidade de cancelamento no plugin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,8 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 == Changelog ==
 =1.1.10 - 13/10/2021 =
 -Lançamento da versão path.
-- **Correção**: Foi adicionado retrocompatibilidade de cancelamento no plugin
+- **Correção**: Foi corrigido um comportamento em que assinaturas do plugin antigo do WooCommerce não conseguiam ser canceladas pelo plugin novo.
+
 
 = 1.1.9 - 04/10/2021 =
 - Lançamento da versão de patch.

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.8.1
 WC requires at least: 3.0.0
 WC tested up to: 5.7.0
 Requires PHP: 5.6
-Stable Tag: 1.1.9
+Stable Tag: 1.1.10
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,10 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+=1.1.10 - 13/10/2021 =
+-Lançamento da versão path.
+- **Correção**: Foi adicionado retrocompatibilidade de cancelamento no plugin
+
 = 1.1.9 - 04/10/2021 =
 - Lançamento da versão de patch.
 - **Correção**: Foi corrigido o comportamento que permitia inserir qualquer tipo de dado no campo referente a numeração do cartão no checkout.

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.9');
+define('VINDI_VERSION', '1.1.10');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -97,10 +97,8 @@ class VindiSubscriptionStatusHandler
      */
     public function get_wc_subscription_id($subscription_id)
     {
-        $new_subscription_id = get_post_meta($subscription_id, 'vindi_subscription_id', true);
-        $old_subscription_id = get_post_meta($subscription_id, 'vindi_wc_subscription_id', true);
-
-        return !empty($new_subscription_id) ? $new_subscription_id : $old_subscription_id;
+        return get_post_meta($subscription_id, 'vindi_subscription_id', true) ? :
+            get_post_meta($subscription_id, 'vindi_wc_subscription_id', true);
     }
 
     public function get_vindi_subscription_id($wc_subscription)

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -100,7 +100,10 @@ class VindiSubscriptionStatusHandler
         $subscription_id = method_exists($wc_subscription, 'get_id')
         ? $wc_subscription->get_id()
         : $wc_subscription->id;
-        return get_post_meta($subscription_id, 'vindi_subscription_id', true);
+        $new_subscription_id = get_post_meta($subscription_id, 'vindi_subscription_id', true);
+        $old_subscription_id = get_post_meta($subscription_id, 'vindi_wc_subscription_id', true);
+
+        return !empty($new_subscription_id) ? $new_subscription_id : $old_subscription_id;
     }
 
     /**

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -108,7 +108,7 @@ class VindiSubscriptionStatusHandler
         $subscription_id = method_exists($wc_subscription, 'get_id')
         ? $wc_subscription->get_id()
         : $wc_subscription->id;
-        return $this->get_wc_subscription_id($subscription_id); 
+        return $this->get_wc_subscription_id($subscription_id);
     }
 
     /**

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -95,15 +95,20 @@ class VindiSubscriptionStatusHandler
     /**
      * @param WC_Subscription $wc_subscription
      */
+    public function get_wc_subscription_id($subscription_id)
+    {
+        $new_subscription_id = get_post_meta($subscription_id, 'vindi_subscription_id', true);
+        $old_subscription_id = get_post_meta($subscription_id, 'vindi_wc_subscription_id', true);
+
+        return !empty($new_subscription_id) ? $new_subscription_id : $old_subscription_id;
+    }
+
     public function get_vindi_subscription_id($wc_subscription)
     {
         $subscription_id = method_exists($wc_subscription, 'get_id')
         ? $wc_subscription->get_id()
         : $wc_subscription->id;
-        $new_subscription_id = get_post_meta($subscription_id, 'vindi_subscription_id', true);
-        $old_subscription_id = get_post_meta($subscription_id, 'vindi_wc_subscription_id', true);
-
-        return !empty($new_subscription_id) ? $new_subscription_id : $old_subscription_id;
+        return $this->get_wc_subscription_id($subscription_id); 
     }
 
     /**

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.9
+ * Version: 1.1.10
  * Requires at least: 4.4
  * Tested up to: 5.8.1
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Foi corrigido um comportamento em que assinaturas do plugin antigo do WooCommerce não conseguiam ser canceladas pelo plugin novo.

## Motivação
Issue #96 

Conforme reportado na issue, o cliente não estava conseguindo realizar cancelamentos no seu plugin devido as assinaturas terem sido criados na nossa primeira versão.

## Solução proposta
Realizamos uma validação para verificar se o metadata da assinatura está com o padrão do plugin antigo e passa a ser considerado na validação de IDs


## Como testar
Baixar a brench e adicioná-la em seu código

Instalar a versão 1 de nosso plug-in versão 5.5.4 e realizar a criação de um produto por assinatura e compra-lo.

Apos esse processo desativar a versão 1 e ativar o plug-in 2 modificado.

Acessar a pagina minha-conta e realizar o cancelamento da assinatura e então verificar se a assinatura foi cancelada também na Vindi.
