### PR TITLE
Altera versão de dependência do WooCommerce Subscriptions para 2.6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 5.8.1
 WC requires at least: 3.0.0
 WC tested up to: 5.7.0
 Requires PHP: 5.6
-Stable Tag: 1.1.10
+Stable Tag: 1.1.11
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+= 1.1.11 - 07/12/2021 =
+-Lançamento da versão de patch.
+- **Correção**: Foi corrigida a versão da dependência necessária para funcionamento do plugin em conjunto ao WooCommerce Subscriptions.
+
+
 = 1.1.10 - 13/10/2021 =
 -Lançamento da versão path.
 - **Correção**: Foi corrigido um comportamento em que assinaturas do plugin antigo do WooCommerce não conseguiam ser canceladas pelo plugin novo.
@@ -153,8 +158,8 @@ Os valores referentes a fretes serão enviados especificamente por assinaturas;
 - **Melhoria**: Juros configuráveis em compras parceladas.
 
 == Upgrade Notice ==
-= 1.1.7 - 05/05/2021 =
-Minor upgrade com nova funcionalidade para o plugin Vindi
+= 1.1.11 - 07/12/2021 =
+Patch de correções para o plugin Vindi
 
 == License ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 == Changelog ==
 = 1.1.11 - 07/12/2021 =
 -Lançamento da versão de patch.
-- **Correção**: Foi corrigida a versão da dependência necessária para funcionamento do plugin em conjunto ao WooCommerce Subscriptions.
+- **Correção**: Foi corrigida a versão da dependência WooCommerce Subscriptions, necessária para funcionamento do plugin.
 
 
 = 1.1.10 - 13/10/2021 =

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.1.10');
+define('VINDI_VERSION', '1.1.11');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/validators/Dependencies.php
+++ b/src/validators/Dependencies.php
@@ -163,7 +163,7 @@ class VindiDependencies
                     'url' => 'http://www.woothemes.com/products/woocommerce-subscriptions/',
                     'version' => [
                         'validation' => '>=',
-                        'number' => '2.2'
+                        'number' => '2.6.1'
                     ]
                 ]
             ]

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.1.10
+ * Version: 1.1.11
  * Requires at least: 4.4
  * Tested up to: 5.8.1
  * WC requires at least: 3.0.0


### PR DESCRIPTION
## O que mudou
Foi alterada a versão da dependência do WooCommerce-Subscriptions para 2.6.1

## Motivação
Resolves: #71 

Devido a utilização do método ```wcs_find_matching_line_item```, foi criada uma depêndencia da versão do WooCommerce Subscriptions [2.6.1](https://github.com/wp-premium/woocommerce-subscriptions/blame/master/includes/wcs-order-functions.php#L931) ou superior dado que o método foi desenvolvido a partir desta versão.

## Solução proposta
Foi alterada a versão do WooCommerce Subscriptions de 2.2 para 2.6.1

## Como testar
Com a loja do WooCommerce configurada:

- Instalar o plugin Vindi WooCommerce
- Instalar o plugin WooCommerce Subscriptions em uma versão inferior a [2.6.1](https://github.com/wp-premium/woocommerce-subscriptions/tags).
- Instalar o plugin Vindi WooCommerce

Deverá ser exibido um alerta de dependência do plugin WooCommerce Subscriptions 2.6.1 ou superior.