### PR TITLE
Corrige exibição do juros no checkout 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 = 1.1.11 - 07/12/2021 =
 -Lançamento da versão de patch.
 - **Correção**: Foi corrigida a versão da dependência WooCommerce Subscriptions, necessária para funcionamento do plugin.
+- **Correção**: Foi corrigido um comportamento que ocasionava a exibição indevida do juros na tela de checkout.
 
 
 = 1.1.10 - 13/10/2021 =

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 = 1.1.11 - 07/12/2021 =
 -Lançamento da versão de patch.
 - **Correção**: Foi corrigida a versão da dependência WooCommerce Subscriptions, necessária para funcionamento do plugin.
-- **Correção**: Foi corrigido um comportamento que ocasionava a exibição indevida do juros na tela de checkout.
+- **Correção**: Foi corrigido um comportamento que ocasionava a exibição indevida de informações sobre juros na tela de checkout.
 
 
 = 1.1.10 - 13/10/2021 =

--- a/src/utils/InterestPriceHandler.php
+++ b/src/utils/InterestPriceHandler.php
@@ -49,7 +49,7 @@ class InterestPriceHandler {
     if (isset($post_data['vindi_cc_installments']) &&
       filter_var($post_data['vindi_cc_installments'], FILTER_SANITIZE_NUMBER_INT) > 1 &&
       $post_data['payment_method'] === 'vindi-credit-card' &&
-      get_option('woocommerce_vindi-credit-card_settings', true)['enable_interest_rate'] == 'yes'
+      get_option('woocommerce_vindi-credit-card_settings', true)['enable_interest_rate'] === 'yes'
     ) {
       global $woocommerce;
       $interest_rate = get_option('woocommerce_vindi-credit-card_settings', true)['interest_rate'];

--- a/src/utils/InterestPriceHandler.php
+++ b/src/utils/InterestPriceHandler.php
@@ -48,7 +48,8 @@ class InterestPriceHandler {
 
     if (isset($post_data['vindi_cc_installments']) &&
       filter_var($post_data['vindi_cc_installments'], FILTER_SANITIZE_NUMBER_INT) > 1 &&
-      $post_data['payment_method'] === 'vindi-credit-card'
+      $post_data['payment_method'] === 'vindi-credit-card' &&
+      get_option('woocommerce_vindi-credit-card_settings', true)['enable_interest_rate'] == 'yes'
     ) {
       global $woocommerce;
       $interest_rate = get_option('woocommerce_vindi-credit-card_settings', true)['interest_rate'];

--- a/src/utils/InterestPriceHandler.php
+++ b/src/utils/InterestPriceHandler.php
@@ -47,9 +47,9 @@ class InterestPriceHandler {
     }
 
     if (isset($post_data['vindi_cc_installments']) &&
-      filter_var($post_data['vindi_cc_installments'], FILTER_SANITIZE_NUMBER_INT) > 1 &&
-      $post_data['payment_method'] === 'vindi-credit-card' &&
-      get_option('woocommerce_vindi-credit-card_settings', true)['enable_interest_rate'] === 'yes'
+        filter_var($post_data['vindi_cc_installments'], FILTER_SANITIZE_NUMBER_INT) > 1 &&
+        $post_data['payment_method'] === 'vindi-credit-card' &&
+        get_option('woocommerce_vindi-credit-card_settings', true)['enable_interest_rate'] === 'yes'
     ) {
       global $woocommerce;
       $interest_rate = get_option('woocommerce_vindi-credit-card_settings', true)['interest_rate'];


### PR DESCRIPTION
## O que mudou
Foi implementada uma validação adicional para que a exibição do juros no checkout só ocorra caso a opção de Juros esteja habilitada nas configurações de pagamento de cartão de crédito Vindi no WooCommerce.

## Motivação
Resolves: #104 

Sem a validação adicionada neste PR, caso o cliente final utilize a opção de parcelamento, será exibido o juros em tela, mesmo que a opção esteja desabilitada nas configurações do cliente Vindi no WooCommerce.

## Solução proposta
Foi adicionada uma validação para exibir o juros na tela de checkout somente se a opção estiver habilitada nas configurações de pagamento do cliente no WooCommerce. 

OBS: O problema é apresentado somente visualmente na tela de checkout, O juros não será cobrado na Vindi caso a opção de Juros no parcelamento esteja desabilitada. Isto ocorre pois a validação adicionada neste PR já está presente no fluxo de adição do produto de juros na função [build_interest_rate_item](https://github.com/vindi/vindi-woocommerce/blob/master/src/utils/PaymentProcessor.php#L603).


## Como testar
Tendo uma plataforma Wordpress configurada, é necessário os seguintes plugins instalados:

- WooCommerce;
- WooCommerce Subscriptions;
- Brazilian Market on WooCommerce;
- Realizar o Download do zip desta branch e instalar no WordPress

Após ter todos os plugins instalados, realizar os passos abaixo:

1. Criar um produto do tipo simples no WooCommerce;
2. Em WooCommerce > Configurações > Pagamentos > Vindi - Cartão de Crédito:
  - Deixar a opção **Habilitar Juros** desmarcada;
  - Adicionar um Valor na opção Taxa de juros ao mês (%);
  - aumentar o número máximo de parcelar para 12x
3. Realizar o fluxo de compra do produto criado no primeiro passo;
4. Selecionar no checkout o número de parcelas como 2x.

Realizando este procedimento, a opção de Juros **NÃO** deverá ser exibida em tela.

Para garantir o funcionamento completo, realizar um novo fluxo de compra com a opção de Juros Habilitada. Para este cenário, o valor do juros deverá ser exibido no checkout.