### PR TITLE
Fix/one time shipping

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -653,7 +653,9 @@ class VindiPaymentProcessor
             $wc_subscription = VindiHelpers::get_matching_subscription($this->order, $order_item);
             $product = $order_item->get_product();
 
-            if ($this->is_subscription_type($product)) {
+            $one_time_shipping = $this->is_one_time_shipping($product) && $this->single_freight ? true : false;
+
+            if ($this->is_subscription_type($product) && !$one_time_shipping) {
                 $shipping_method = $wc_subscription->get_shipping_method();
                 $get_total_shipping = $wc_subscription->get_total_shipping();
             }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -441,7 +441,7 @@ class VindiPaymentProcessor
             }
             return $this->single_freight ? 1 : null;
 
-        } elseif (!$this->is_subscription_type($product) || $this->is_one_time_shipping($product)) {
+        } elseif (!$this->is_subscription_type($product)) {
             return 1;
         }
 


### PR DESCRIPTION
### Github Issue #92 

O problema é que essa funcionalidade corrige justamente o que a VINDI questiona no Issue #92, mas não pode ser utilizada pois o plugin não suporta ela, pois quando ativa, ela  enviava o valor da entrega como zero, mesmo quando há um valor a ser pago.

No arquivo que monta os dados que serão enviados no request, há uma verificação se o produto é uma subscription e caso seja ele busca o frete da inscrição. O que acontece é que, o frete é cobrado separadamente de forma única, então ele não vai fazer parte da assinatura e sim da order.

Nesse caso o frete vai ser contato na order, então o que eu fiz foi adicionar outra verificação que vai checar se o produto é um produto de entrega única. Se for, vai ser buscado o frete separado da subscription, se não ele vai seguir o fluxo normalmente.