### PR TITLE
fix: invertendo verificação que dispara a notificação para ativar a o…

### DIFF
--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -333,9 +333,10 @@ class VindiSettings extends WC_Settings_API
     **/
     public function wcs_automatic_payment_settings()
     {
-        if('yes' != get_option('woocommerce_subscriptions_turn_off_automatic_payments'))
-            return;
-
-        $this->get_template('wcs-automatic-payment-deactivated-message.html.php');
+        if('yes' !== get_option('woocommerce_subscriptions_turn_off_automatic_payments')) {
+          $this->get_template('wcs-automatic-payment-deactivated-message.html.php');
+        }
+        
+        return;
     }
 }

--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -333,8 +333,12 @@ class VindiSettings extends WC_Settings_API
     **/
     public function wcs_automatic_payment_settings()
     {
-        if('yes' !== get_option('woocommerce_subscriptions_turn_off_automatic_payments')) {
-          $this->get_template('wcs-automatic-payment-deactivated-message.html.php');
+        $opt = get_option('woocommerce_subscriptions_turn_off_automatic_payments');
+
+        if ('yes' !== $opt) {
+            $this->get_template(
+                'wcs-automatic-payment-deactivated-message.html.php'
+            );
         }
         
         return;

--- a/src/templates/wcs-automatic-payment-deactivated-message.html.php
+++ b/src/templates/wcs-automatic-payment-deactivated-message.html.php
@@ -6,6 +6,6 @@
     </h3>
     <p>
         O plugin Vindi agora utiliza os mecanismos do WooCommerce para gerenciar as renovações das assinaturas.<br>
-        Para isso, você precisa desmarcar a opção "<i><?php echo __('Turn off Automatic Payments', 'woocommerce-subscriptions'); ?></i>" nas <a href="admin.php?page=wc-settings&tab=subscriptions">configurações do WooCommerce Subscriptions</a>.
+        Para isso, você precisa marcar a opção "<i><?php echo __('Turn off Automatic Payments', 'woocommerce-subscriptions'); ?></i>" nas <a href="admin.php?page=wc-settings&tab=subscriptions">configurações do WooCommerce Subscriptions</a>.
     </p>
 </div>

--- a/src/templates/wcs-automatic-payment-deactivated-message.html.php
+++ b/src/templates/wcs-automatic-payment-deactivated-message.html.php
@@ -1,11 +1,19 @@
-<?php if (!defined( 'ABSPATH')) exit; ?>
+<?php if (!defined('ABSPATH')) exit; ?>
 
 <div class="error notice">
     <h3>
         <?php echo __('Configuração da renovação de assinaturas', VINDI_IDENTIFIER );?>
     </h3>
     <p>
-        O plugin Vindi agora utiliza os mecanismos do WooCommerce para gerenciar as renovações das assinaturas.<br>
-        Para isso, você precisa marcar a opção "<i><?php echo __('Turn off Automatic Payments', 'woocommerce-subscriptions'); ?></i>" nas <a href="admin.php?page=wc-settings&tab=subscriptions">configurações do WooCommerce Subscriptions</a>.
+        O plugin Vindi agora utiliza os mecanismos do WooCommerce para gerenciar as 
+        renovações das assinaturas.<br>Para isso, você precisa marcar a opção "
+        <i>
+            <?php 
+                echo __('Turn off Automatic Payments', 'woocommerce-subscriptions'); 
+            ?>
+        </i>" nas 
+        <a href="admin.php?page=wc-settings&tab=subscriptions">
+            configurações do WooCommerce Subscriptions
+        </a>.
     </p>
 </div>

--- a/src/templates/wcs-automatic-payment-deactivated-message.html.php
+++ b/src/templates/wcs-automatic-payment-deactivated-message.html.php
@@ -2,18 +2,20 @@
 
 <div class="error notice">
     <h3>
-        <?php echo __('Configuração da renovação de assinaturas', VINDI_IDENTIFIER );?>
+        <?php
+            echo __('Configuração da renovação de assinaturas', VINDI_IDENTIFIER );
+        ?>
     </h3>
     <p>
-        O plugin Vindi agora utiliza os mecanismos do WooCommerce para gerenciar as 
-        renovações das assinaturas.<br>Para isso, você precisa marcar a opção "
+        O plugin Vindi agora utiliza os mecanismos do WooCommerce para gerenciar as
+         renovações das assinaturas.<br>Para isso, você precisa marcar a opção "
         <i>
-            <?php 
-                echo __('Turn off Automatic Payments', 'woocommerce-subscriptions'); 
+            <?php
+                echo __('Turn off Automatic Payments', 'woocommerce-subscriptions');
             ?>
-        </i>" nas 
+        </i>" nas
         <a href="admin.php?page=wc-settings&tab=subscriptions">
-            configurações do WooCommerce Subscriptions
+             configurações do WooCommerce Subscriptions
         </a>.
     </p>
 </div>

--- a/src/templates/wcs-automatic-payment-deactivated-message.html.php
+++ b/src/templates/wcs-automatic-payment-deactivated-message.html.php
@@ -3,7 +3,7 @@
 <div class="error notice">
     <h3>
         <?php
-            echo __('Configuração da renovação de assinaturas', VINDI_IDENTIFIER );
+            echo __('Configuração da renovação de assinaturas', VINDI_IDENTIFIER);
         ?>
     </h3>
     <p>


### PR DESCRIPTION
#117 

## O que mudou
Verificação responsável por disparar a notificação para ativar a opção "Turn off Automatic Payments".

## Motivação
_Descreva a motivação deste PR. Explique qual é o problema que queremos resolver._

## Solução proposta
Inverter a verificação:
```PHP
/**
* Warning if WCS automatic payments settings are disabled
**/
public function wcs_automatic_payment_settings()
{
    if('yes' !== get_option('woocommerce_subscriptions_turn_off_automatic_payments')) {
      $this->get_template('wcs-automatic-payment-deactivated-message.html.php');
    }
    
    return;
}
```
_/vindi-payment-gateway/src/includes/admin/Settings.php line 334~343_

## Como testar
Ativar a opção nas configurações do plugin WooCommerce Subscription.
