### PR TITLE
Fix/trial product checkout

### DIFF
--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -78,6 +78,9 @@ class WC_Vindi_Payment extends AbstractInstance
     add_action('woocommerce_api_' . self::WC_API_CALLBACK, array(
       $this->webhooks, 'handle'
     ));
+
+    remove_action('woocommerce_before_calculate_totals', 'WC_Subscriptions_Cart::add_calculation_price_filter', 10);
+		add_action('woocommerce_before_calculate_totals', [ $this, 'add_calculation_price_filter' ], 99);
   }
 
   /**
@@ -149,6 +152,15 @@ class WC_Vindi_Payment extends AbstractInstance
     $methods[] = new VindiBankSlipGateway($this->settings, $this->controllers);
 
     return $methods;
+  }
+
+  /**
+   * Sobrescreve o método que remove os métodos de pagamento para assinaturas com trial
+   * @return bool
+   */
+  public function add_calculation_price_filter()
+  {
+    return false;
   }
 }
 

--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -79,8 +79,7 @@ class WC_Vindi_Payment extends AbstractInstance
       $this->webhooks, 'handle'
     ));
 
-    remove_action('woocommerce_before_calculate_totals', 'WC_Subscriptions_Cart::add_calculation_price_filter', 10);
-		add_action('woocommerce_before_calculate_totals', [ $this, 'add_calculation_price_filter' ], 99);
+    add_filter( 'woocommerce_cart_needs_payment', [ $this, 'filter_woocommerce_cart_needs_payment' ], 10, 2 );
   }
 
   /**
@@ -158,9 +157,9 @@ class WC_Vindi_Payment extends AbstractInstance
    * Sobrescreve o método que remove os métodos de pagamento para assinaturas com trial
    * @return bool
    */
-  public function add_calculation_price_filter()
+  public function filter_woocommerce_cart_needs_payment()
   {
-    return false;
+    return true;
   }
 }
 

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1170,7 +1170,13 @@ class VindiPaymentProcessor
             $status = $this->vindi_settings->get_return_status();
         } else {
             $status = 'pending';
+
+            if ($this->order_has_trial()) {
+                $status = $this->vindi_settings->get_return_status();
+                $status_message = __('Aguardando cobrança após a finalização do período grátis.', VINDI);
+            }
         }
+        
         $this->order->update_status($status, $status_message);
 
         return array(
@@ -1276,6 +1282,27 @@ class VindiPaymentProcessor
     protected function subscription_has_trial(WC_Product $product)
     {
         return $this->is_subscription_type($product) && class_exists('WC_Subscriptions_Product') && WC_Subscriptions_Product::get_trial_length($product->get_id()) > 0;
+    }
+
+
+    /**
+     * Check if the order has a subscription with trial period
+     *
+     * @return bool
+     */
+    protected function order_has_trial()
+    {
+        $has_trial   = false;
+        $order_items = $this->order->get_items();
+
+        foreach ($order_items as $order_item) {
+            $product = $order_item->get_product();
+            if ($this->subscription_has_trial($product)) {
+                $has_trial = true;
+            }
+        }
+        
+        return $has_trial;
     }
 
     /**


### PR DESCRIPTION
## O que mudou
Adição de hook para certificar a renderização dos métodos de pagamento.
Verificação de pedidos com free trial e alteração de status para concluído.

## Motivação
Produtos com free trial e renovações automáticas ativada não renderização os métodos de pagamento no checkout. Como explicado na Issue #97 

## Solução proposta
Adicionei um hook que fazia o bloqueio da renderização dos métodos de pagamento na página de checkout. Isso fez com que os métodos de pagamento da Vindi voltassem a aparecer.
![trial_product_checkout](https://user-images.githubusercontent.com/71287681/190410111-3b9fa504-dbea-43aa-9f59-9f2641ab2d48.png)

A assinatura com o free trial continua sendo enviada na maneira correta, com a cobrança somente após o período de teste cadastrado no produto:
![trial_product_vindi](https://user-images.githubusercontent.com/71287681/190410214-61f579cd-0afc-425f-a95e-8104db790519.png)
![trial_product_woo](https://user-images.githubusercontent.com/71287681/190410241-2e8c7c77-3abd-4086-a9ae-381579ab4dff.png)

Além disso, adicionei uma verificação durante o processamento do pagamento da criação da nova assinatura. Essa condicional verifica se o produto do pedido é um pedido com free trial, e caso seja, já mantém a order como completa e a assinatura como ativa.

Dessa forma, visando um controle de acesso a conteúdo ou até mesmo liberação de um produto, o usuário vai poder ter acesso imediato. Até que seja feita a cobrança após o período de teste.
![trial_product_woocommerce](https://user-images.githubusercontent.com/71287681/190410338-b54e310a-19c1-4d25-823a-16cf8769ba0a.png)

## Como testar
Efetuar a compra de um produto com free trial.