### PR TITLE
Feat/controller credit installment

### DIFF
--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -50,6 +50,11 @@ class WC_Vindi_Payment extends AbstractInstance
    */
   private $subscription_status_handler;
 
+  /**
+   * @var ProductsMetabox
+   */
+  private $product_metabox;
+
   public function __construct()
   {
 
@@ -66,6 +71,7 @@ class WC_Vindi_Payment extends AbstractInstance
     $this->subscription_status_handler = new VindiSubscriptionStatusHandler($this->settings);
     $this->vindi_status_notifier = new VindiProductStatus($this->settings);
     $this->interest_price_handler = new InterestPriceHandler();
+    $this->product_metabox = new ProductsMetaBox;
 
     /**
       * Add Gateway to Woocommerce
@@ -101,6 +107,7 @@ class WC_Vindi_Payment extends AbstractInstance
     require_once $this->getPath() . '/utils/RedirectCheckout.php';
 
     require_once $this->getPath() . '/includes/admin/CouponsMetaBox.php';
+    require_once $this->getPath() . '/includes/admin/ProductsMetabox.php';
     require_once $this->getPath() . '/includes/admin/Settings.php';
     require_once $this->getPath() . '/includes/gateways/CreditPayment.php';
     require_once $this->getPath() . '/includes/gateways/BankSlipPayment.php';

--- a/src/assets/js/product.js
+++ b/src/assets/js/product.js
@@ -1,0 +1,32 @@
+class Product {
+    constructor() {
+        this.setEvents();
+    }
+
+    setEvents() {
+        const type = document.querySelector("#_subscription_period");
+        if (!type) return;
+
+        this.showCustom();
+        type.addEventListener("change", () => {
+            this.showCustom();
+        });
+    }
+
+    showCustom() {
+        const custom = document.querySelector("#vindi_max_credit_installments");
+        const type   = document.querySelector("#_subscription_period");
+        if (!custom) return;
+
+        const parent = custom.parentElement;
+        if (type.value === 'year') {
+            parent.style.display = "block";
+        } else {
+            parent.style.display = "none";
+        }
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    new Product;
+})

--- a/src/assets/js/product.js
+++ b/src/assets/js/product.js
@@ -6,30 +6,68 @@ class Product {
     setEvents() {
         const period = document.querySelector("#_subscription_period");
         const type   = document.querySelector("#product-type");
-        if (!type || !period) return;
+        const middle = document.querySelector("#_subscription_period_interval");
 
-        this.showCustom();
-        period.addEventListener("change", () => {
-            this.showCustom();
-        });
+        const elements = [period, type, middle];
 
-        type.addEventListener("change", () => {
-            this.showCustom();
+        this.showCustom(this.getMaxInstallments());
+        elements.forEach(element => {
+            if (element) {
+                element.addEventListener("change", () => {
+                    this.showCustom(this.getMaxInstallments());
+                });
+            }
         });
     }
 
-    showCustom() {
+    showCustom(show) {
         const custom = document.querySelector("#vindi_max_credit_installments");
-        const period = document.querySelector("#_subscription_period");
-        const type   = document.querySelector("#product-type");
 
         if (!custom) return;
 
         const parent = custom.parentElement;
-        if (period.value === 'year' && type.value.includes("subscription") ) {
+        if (show) {
             parent.style.display = "block";
+
+            this.setMaxInstallments(show);
         } else {
             parent.style.display = "none";
+        }
+
+    }
+
+    getMaxInstallments() {
+        const period = document.querySelector("#_subscription_period");
+        const middle = document.querySelector("#_subscription_period_interval");
+
+        const type   = document.querySelector("#product-type");
+
+        if ( ! type.value.includes("subscription") ) return;
+
+        if ( period.value === 'year' ) {
+            return 12;
+        }
+
+        if( period.value === 'month' ) {
+            if (middle.value) {
+                if (middle.value == 1) return;
+                return middle.value;
+            }
+        }
+
+        return false;
+    }
+
+    setMaxInstallments(max) {
+        if (!max) return;
+
+        const custom = document.querySelector("#vindi_max_credit_installments");
+        if (custom) {
+            custom.setAttribute("max", max);
+
+            if (custom.value > max) {
+                custom.value = max;
+            }
         }
     }
 }

--- a/src/assets/js/product.js
+++ b/src/assets/js/product.js
@@ -4,10 +4,15 @@ class Product {
     }
 
     setEvents() {
-        const type = document.querySelector("#_subscription_period");
-        if (!type) return;
+        const period = document.querySelector("#_subscription_period");
+        const type   = document.querySelector("#product-type");
+        if (!type || !period) return;
 
         this.showCustom();
+        period.addEventListener("change", () => {
+            this.showCustom();
+        });
+
         type.addEventListener("change", () => {
             this.showCustom();
         });
@@ -15,11 +20,13 @@ class Product {
 
     showCustom() {
         const custom = document.querySelector("#vindi_max_credit_installments");
-        const type   = document.querySelector("#_subscription_period");
+        const period = document.querySelector("#_subscription_period");
+        const type   = document.querySelector("#product-type");
+
         if (!custom) return;
 
         const parent = custom.parentElement;
-        if (type.value === 'year') {
+        if (period.value === 'year' && type.value.includes("subscription") ) {
             parent.style.display = "block";
         } else {
             parent.style.display = "none";

--- a/src/assets/js/product.js
+++ b/src/assets/js/product.js
@@ -65,7 +65,7 @@ class Product {
         if (custom) {
             custom.setAttribute("max", max);
 
-            if (custom.value > max) {
+            if (parseInt(custom.value) > parseInt(max)) {
                 custom.value = max;
             }
         }

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -79,9 +79,12 @@ class PlansController
 
         $data = $variation_product->get_data();
 
-        $interval_type = $variation_product->get_meta('_subscription_period');
-        $interval_count = $variation_product->get_meta('_subscription_period_interval');
-        $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
+        $interval_type     = $variation_product->get_meta('_subscription_period');
+        $interval_count    = $variation_product->get_meta('_subscription_period_interval');
+        $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
+        $plan_installments = $variation_product->get_meta('vindi_max_credit_installments');
+
+        if ( ! $plan_installments || $plan_installments === 0 ) $plan_installments = 1;
 
         $trigger_day = VindiConversions::convertTriggerToDay(
                         $product->get_meta('_subscription_trial_length'),
@@ -113,7 +116,7 @@ class PlansController
           'billing_trigger_day' => $trigger_day,
           'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
           'code' => 'WC-' . $data['id'],
-          'installments' => 1,
+          'installments' => $plan_installments,
           'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
           'plan_items' => array(
             ($product->get_meta('_subscription_length') == 0) ? array(
@@ -154,6 +157,9 @@ class PlansController
       $product->get_meta('_subscription_trial_period')
     );
 
+    $plan_installments = $product->get_meta('vindi_max_credit_installments');
+    if ( ! $plan_installments || $plan_installments === 0 ) $plan_installments = 1;
+
     // Creates the product within the Vindi
     $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
     $createdProduct = !empty($vindi_product_id) ?
@@ -179,7 +185,7 @@ class PlansController
       'billing_trigger_day' => $trigger_day,
       'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
       'code' => 'WC-' . $data['id'],
-      'installments' => 1,
+      'installments' => $plan_installments,
       'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
       'plan_items' => array(
         ($product->get_meta('_subscription_length') == 0) ? array(
@@ -257,9 +263,12 @@ class PlansController
 
         $data = $variation_product->get_data();
 
-        $interval_type = $variation_product->get_meta('_subscription_period');
-        $interval_count = $variation_product->get_meta('_subscription_period_interval');
-        $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
+        $interval_type     = $variation_product->get_meta('_subscription_period');
+        $interval_count    = $variation_product->get_meta('_subscription_period_interval');
+        $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
+        $plan_installments = $variation_product->get_meta('vindi_max_credit_installments');
+
+        if ( ! $plan_installments || $plan_installments === 0 ) $plan_installments = 1;
 
         $trigger_day = VindiConversions::convertTriggerToDay(
                         $product->get_meta('_subscription_trial_length'),
@@ -292,7 +301,7 @@ class PlansController
             'billing_trigger_day' => $trigger_day,
             'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
             'code' => 'WC-' . $data['id'],
-            'installments' => 1,
+            'installments' => $plan_installments,
             'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
           )
         );
@@ -342,7 +351,9 @@ class PlansController
       )
     );
 
-    $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id', true);
+    $vindi_plan_id     = get_post_meta($post_id, 'vindi_plan_id', true);
+    $plan_installments = $product->get_meta('vindi_max_credit_installments');
+    if ( ! $plan_installments || $plan_installments === 0 ) $plan_installments = 1;
 
     // Updates the plan within the Vindi
     $updatedPlan = $this->routes->updatePlan(
@@ -355,7 +366,7 @@ class PlansController
         'billing_trigger_day' => $trigger_day,
         'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
         'code' => 'WC-' . $data['id'],
-        'installments' => 1,
+        'installments' => $plan_installments,
         'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
       )
     );

--- a/src/includes/admin/ProductsMetabox.php
+++ b/src/includes/admin/ProductsMetabox.php
@@ -51,17 +51,22 @@ class ProductsMetaBox
 
     public function save_woocommerce_product_custom_fields( $post_id )
     {
-        $subscription_period = isset( $_POST['_subscription_period'] ) ? $_POST['_subscription_period'] : false; 
-        $installments = isset( $_POST['vindi_max_credit_installments'] ) ? intval( $_POST['vindi_max_credit_installments'] ) : false;
-        $product_type = isset( $_POST['product-type'] ) ? sanitize_text_field( $_POST['product-type'] ) : false;
+        $subscription_period = isset( $_POST['_subscription_period'] ) ? sanitize_text_field( $_POST['_subscription_period'] ) : false; 
+        $product_type        = isset( $_POST['product-type'] ) ? sanitize_text_field( $_POST['product-type'] ) : false;
+        $installments        = isset( $_POST['vindi_max_credit_installments'] ) ? intval( $_POST['vindi_max_credit_installments'] ) : 1;
+        $interval_time       = isset( $_POST['_subscription_period_interval'] ) ? intval( $_POST['_subscription_period_interval'] ) : 1;
 
         if ( strpos( $product_type, 'subscription' ) === false ) return;
 
         if ( $subscription_period ) {
             if ( $subscription_period === 'year' ) {
                 if ( $installments > 12 ) $installments = 12;
-            } else {
-                $installments = 0;
+            }
+
+            if(  $subscription_period === 'month' ) {
+                if ( $installments > $interval_time ) {
+                    $installments = $interval_time;
+                }
             }
         }
 

--- a/src/includes/admin/ProductsMetabox.php
+++ b/src/includes/admin/ProductsMetabox.php
@@ -20,7 +20,7 @@ class ProductsMetaBox
 
         if ( isset( $post->ID ) ) {
             $product = wc_get_product( $post->ID );
-            if ( $product->is_type( 'subscription' ) ) {
+            if ( $product->is_type( 'subscription' ) || $post->post_status === 'auto-draft' ) {
 
                 if( $this->check_credit_payment_active( $woocommerce ) ) {
 
@@ -53,6 +53,9 @@ class ProductsMetaBox
     {
         $subscription_period = isset( $_POST['_subscription_period'] ) ? $_POST['_subscription_period'] : false; 
         $installments = isset( $_POST['vindi_max_credit_installments'] ) ? intval( $_POST['vindi_max_credit_installments'] ) : false;
+        $product_type = isset( $_POST['product-type'] ) ? sanitize_text_field( $_POST['product-type'] ) : false;
+
+        if ( strpos( $product_type, 'subscription' ) === false ) return;
 
         if ( $subscription_period ) {
             if ( $subscription_period === 'year' ) {

--- a/src/includes/admin/ProductsMetabox.php
+++ b/src/includes/admin/ProductsMetabox.php
@@ -1,0 +1,79 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * WC_Meta_Box_Coupon_Data Class updated with custom fields.
+ */
+class ProductsMetaBox 
+{
+    public function __construct()
+    {
+        add_action( 'woocommerce_product_options_general_product_data', [ $this, 'woocommerce_product_custom_fields'] );
+        add_action( 'woocommerce_process_product_meta', [ $this, 'save_woocommerce_product_custom_fields' ] );
+    }
+    
+    public function woocommerce_product_custom_fields () {
+        global $woocommerce, $post;
+
+        if ( isset( $post->ID ) ) {
+            $product = wc_get_product( $post->ID );
+            if ( $product->is_type( 'subscription' ) ) {
+
+                if( $this->check_credit_payment_active( $woocommerce ) ) {
+
+                    echo '<div class="product_custom_field">';
+    
+                    woocommerce_wp_text_input(
+                        array(
+                            'id' => 'vindi_max_credit_installments',
+                            'value'   => get_post_meta( get_the_ID(), 'vindi_max_credit_installments', true ),
+                            'label' => __( 'Máximo de parcelas com cartão de crédito', 'woocommerce' ),
+                            'type' => 'number',
+                            'description' => sprintf( 'Esse campo controla a quantidade máxima de parcelas para compras com cartão de crédito. <strong> %s </strong>',
+                                '(Somente para assinaturas anuais!)'
+                            ),
+                            "desc_tip"    => true,
+                            'custom_attributes' => array(
+                                'max' => '12',
+                                'min' => '0'
+                            )
+                        )
+                    );
+                    
+                    echo '</div>';
+                }
+            }
+        }
+    }
+
+    public function save_woocommerce_product_custom_fields( $post_id )
+    {
+        error_log( var_export( $_POST, true ) );
+        $subscription_period = isset( $_POST['_subscription_period'] ) ? $_POST['_subscription_period'] : false; 
+        $installments = isset( $_POST['vindi_max_credit_installments'] ) ? intval( $_POST['vindi_max_credit_installments'] ) : false;
+
+        if ( $subscription_period ) {
+            if ( $subscription_period === 'year' ) {
+                if ( $installments > 12 ) $installments = 12;
+            } else {
+                $installments = 0;
+            }
+        }
+
+        update_post_meta( $post_id, 'vindi_max_credit_installments', $installments );
+    }
+
+    private function check_credit_payment_active( $wc )
+    {
+        if ( $wc ) {
+            $gateways = $wc->payment_gateways->get_available_payment_gateways();
+
+            foreach ( $gateways as $key => $gateway ) {
+                if ( $key === 'vindi-credit-card' ) return true;
+            }
+        }
+    }
+}

--- a/src/includes/admin/ProductsMetabox.php
+++ b/src/includes/admin/ProductsMetabox.php
@@ -51,7 +51,6 @@ class ProductsMetaBox
 
     public function save_woocommerce_product_custom_fields( $post_id )
     {
-        error_log( var_export( $_POST, true ) );
         $subscription_period = isset( $_POST['_subscription_period'] ) ? $_POST['_subscription_period'] : false; 
         $installments = isset( $_POST['vindi_max_credit_installments'] ) ? intval( $_POST['vindi_max_credit_installments'] ) : false;
 

--- a/src/utils/FrontendFilesLoader.php
+++ b/src/utils/FrontendFilesLoader.php
@@ -19,6 +19,7 @@ class FrontendFilesLoader {
     wp_enqueue_script('vindi_woocommerce_admin_js');
     wp_register_style('vindi_woocommerce_admin_style', plugins_url('/assets/css/admin.css', plugin_dir_path(__FILE__)), array(), VINDI_VERSION);
     wp_enqueue_style('vindi_woocommerce_admin_style');
+    wp_enqueue_script( "vindi_products",  plugins_url('/assets/js/product.js', plugin_dir_path(__FILE__)) );
   }
   public static function frontendFiles()
   {


### PR DESCRIPTION
# GitHub Issue #77 

## O que mudou
Foi inserido um novo campo para controlar a quantidade máxima de parcelas de crédito no cadastro de assinaturas.

## Motivação
Não era possível configurar essa opção. E ao atualizar o produto no WooCommerce sempre era enviado como parcela única. 

## Solução proposta
Adicionei um novo campo no cadastro de produtos para poder preencher a quantidade máxima de parcelas que deseja disponibilizar para a assinatura em questão.
![installments](https://user-images.githubusercontent.com/71287681/192033923-eb811193-1a6a-4ed9-b104-1f225dfcb5f5.png)
Essa opção só vai aparece em produtos que são do tipo assinatura e que sejam assinaturas anuais. Isso pois o WC Subscription só disponibiliza cobranças diarias, semanais, mensais e anuais. 

## Como testar
Acessar edição de assinaturas.