### PR TITLE
Feat/new logger

### DIFF
--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -18,6 +18,7 @@ class VindiRoutes
 
     $this->vindi_settings = $vindi_settings;
     $this->api = $this->vindi_settings->api;
+    $this->logger = $vindi_settings->logger;
   }
 
   /**
@@ -51,6 +52,7 @@ class VindiRoutes
   {
 
     $response = $this->api->request('plans', 'POST', $data);
+    $this->logger->plan(sprintf("\nCreate Plan:\n %s", json_encode($response)));
 
     return $response['plan'];
   }
@@ -70,6 +72,7 @@ class VindiRoutes
       filter_var($plan_id, FILTER_SANITIZE_NUMBER_INT)
     ), 'PUT', $data);
 
+    $this->logger->plan(sprintf("\nUpdate Plan:\n %s", json_encode($response)));
     return $response['plan'];
   }
 
@@ -82,8 +85,9 @@ class VindiRoutes
    */
   public function createProduct($data)
   {
-
     $response = $this->api->request('products', 'POST', $data);
+    $this->logger->product(sprintf("\nCreate product:\n %s", json_encode($response)));
+
     return $response['product'];
   }
 
@@ -96,11 +100,12 @@ class VindiRoutes
    */
   public function updateProduct($product_id, $data)
   {
-
     $response = $this->api->request(sprintf(
       'products/%s',
       filter_var($product_id, FILTER_SANITIZE_NUMBER_INT)
     ), 'PUT', $data);
+
+    $this->logger->product(sprintf("\nUpdate product:\n %s", json_encode($response)));
     return $response['product'];
   }
 
@@ -113,8 +118,9 @@ class VindiRoutes
    */
   public function createCustomer($data)
   {
-
     $response = $this->api->request('customers', 'POST', $data);
+
+    $this->logger->customer(sprintf("\nCreate customer:\n %s", json_encode($response)));
     return $response['customer'];
   }
 
@@ -127,12 +133,12 @@ class VindiRoutes
    */
   public function updateCustomer($user_id, $data)
   {
-
     $response = $this->api->request(sprintf(
       'customers/%s',
       filter_var($user_id, FILTER_SANITIZE_NUMBER_INT)
     ), 'PUT', $data);
 
+    $this->logger->customer(sprintf("\nUpdate customer:\n %s", json_encode($response)));
     return $response['customer'];
   }
 
@@ -151,6 +157,7 @@ class VindiRoutes
       filter_var($user_id, FILTER_SANITIZE_NUMBER_INT)
     ), 'DELETE');
 
+    $this->logger->customer(sprintf("\nDelete customer:\n %s", json_encode($response)));
     return $response['customer'];
   }
 

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -237,7 +237,7 @@ class VindiApi
 
     $data_to_log = null !== $data_to_log ? $this->build_body($data_to_log) : $body;
 
-    $this->logger->log(sprintf("[Request #%s]: Novo Request para a API.\n%s %s\n%s", $request_id, $method, $url, $data_to_log));
+    $this->logger->request(sprintf("[Request #%s]: Novo Request para a API.\n%s %s\n%s", $request_id, $method, $url, $data_to_log));
 
     $response = wp_remote_post($url, array(
       'headers' => array(
@@ -252,18 +252,18 @@ class VindiApi
     ));
 
     if (is_wp_error($response)) {
-      $this->logger->log(sprintf("[Request #%s]: Erro ao fazer request! %s", $request_id, print_r($response, true)));
+      $this->logger->request(sprintf("[Request #%s]: Erro ao fazer request! %s", $request_id, print_r($response, true)));
 
       return false;
     }
 
     $status = sprintf('%s %s', $response['response']['code'], $response['response']['message']);
-    $this->logger->log(sprintf("[Request #%s]: Nova Resposta da API.\n%s\n%s", $request_id, $status, print_r($response['body'], true)));
+    $this->logger->request(sprintf("[Request #%s]: Nova Resposta da API.\n%s\n%s", $request_id, $status, print_r($response['body'], true)));
 
     $response_body = wp_remote_retrieve_body($response);
 
     if (!$response_body) {
-      $this->logger->log(sprintf('[Request #%s]: Erro ao recuperar corpo do request! %s', $request_id, print_r($response, true)));
+      $this->logger->request(sprintf('[Request #%s]: Erro ao recuperar corpo do request! %s', $request_id, print_r($response, true)));
 
       return false;
     }

--- a/src/services/Logger.php
+++ b/src/services/Logger.php
@@ -26,12 +26,68 @@ class VindiLogger
   }
 
   /**
+   * Create order log
+   * @return bool
+   */
+  public function order($message)
+  {
+    return $this->log($message, 'order');
+  }
+
+  /**
+   * Create product log
+   * @return bool
+   */
+  public function product($message)
+  {
+    return $this->log($message, 'product');
+  }
+
+  /**
+   * Create plan log
+   * @return bool
+   */
+  public function plan($message)
+  {
+    return $this->log($message, 'plan');
+  }
+
+  /**
+   * Create webhook log
+   * @return bool
+   */
+  public function webhook($message)
+  {
+    return $this->log($message, 'webhook');
+  }
+
+  /**
+   * Create customer log
+   * @return bool
+   */
+  public function customer($message)
+  {
+    return $this->log($message, 'customer');
+  }
+
+  /**
+   * Create request log
+   * @return bool
+   */
+  public function request($message)
+  {
+    return $this->log($message, 'request-response');
+  }
+
+  /**
    * @return boolean
    */
-  public function log($message)
+  public function log($message, $type = '')
   {
     if ($this->is_active) {
-      $this->main_logger->add($this->identifier, $message);
+
+      $id = $this->identifier . $type;
+      $this->main_logger->add($id, $message);
       return true;
     }
 

--- a/src/services/Logger.php
+++ b/src/services/Logger.php
@@ -31,7 +31,7 @@ class VindiLogger
    */
   public function order($message)
   {
-    return $this->log($message, 'order');
+    return $this->log($message, '-order');
   }
 
   /**
@@ -40,7 +40,7 @@ class VindiLogger
    */
   public function product($message)
   {
-    return $this->log($message, 'product');
+    return $this->log($message, '-product');
   }
 
   /**
@@ -49,7 +49,7 @@ class VindiLogger
    */
   public function plan($message)
   {
-    return $this->log($message, 'plan');
+    return $this->log($message, '-plan');
   }
 
   /**
@@ -58,7 +58,7 @@ class VindiLogger
    */
   public function webhook($message)
   {
-    return $this->log($message, 'webhook');
+    return $this->log($message, '-webhook');
   }
 
   /**
@@ -67,7 +67,7 @@ class VindiLogger
    */
   public function customer($message)
   {
-    return $this->log($message, 'customer');
+    return $this->log($message, '-customer');
   }
 
   /**
@@ -76,7 +76,7 @@ class VindiLogger
    */
   public function request($message)
   {
-    return $this->log($message, 'request-response');
+    return $this->log($message, '-request-response');
   }
 
   /**

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -35,12 +35,12 @@ class VindiWebhooks
       die('invalid access token');
     }
 
-    $this->vindi_settings->logger->log(sprintf(__('Novo Webhook chamado: %s', VINDI), $raw_body));
+    $this->vindi_settings->logger->webhook(sprintf(__('Novo Webhook chamado: %s', VINDI), $raw_body));
 
     try {
       $this->process_event($body);
     } catch (Exception $e) {
-      $this->vindi_settings->logger->log($e->getMessage());
+      $this->vindi_settings->logger->webhook($e->getMessage());
 
       if(2 === $e->getCode()) {
         header("HTTP/1.0 422 Unprocessable Entity");
@@ -70,11 +70,11 @@ class VindiWebhooks
     $data = $body->event->data;
 
     if(method_exists($this, $type)) {
-      $this->vindi_settings->logger->log(sprintf(__('Novo Evento processado: %s', VINDI), $type));
+      $this->vindi_settings->logger->webhook(sprintf(__('Novo Evento processado: %s', VINDI), $type));
       return $this->{$type}($data);
     }
 
-    $this->vindi_settings->logger->log(sprintf(__('Evento do webhook ignorado pelo plugin: ', VINDI), $type));
+    $this->vindi_settings->logger->webhook(sprintf(__('Evento do webhook ignorado pelo plugin: ', VINDI), $type));
   }
 
   /**
@@ -83,7 +83,7 @@ class VindiWebhooks
    */
   private function test($data)
   {
-    $this->vindi_settings->logger->log(__('Evento de teste do webhook.', VINDI));
+    $this->vindi_settings->logger->webhook(__('Evento de teste do webhook.', VINDI));
   }
 
   /**
@@ -116,7 +116,7 @@ class VindiWebhooks
       'bank_slip_url' => $renew_infos['bill_print_url'],
     );
     update_post_meta($order->id, 'vindi_order', $order_post_meta);
-    $this->vindi_settings->logger->log('Novo Período criado: Pedido #'.$order->id);
+    $this->vindi_settings->logger->webhook('Novo Período criado: Pedido #'.$order->id);
 
     // We've already processed the renewal
     remove_action( 'woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal' );

--- a/src/utils/PaymentGateway.php
+++ b/src/utils/PaymentGateway.php
@@ -175,7 +175,7 @@ abstract class VindiPaymentGateway extends WC_Payment_Gateway_CC
   public function process_payment($order_id)
   {
     $order_id = filter_var($order_id, FILTER_SANITIZE_NUMBER_INT);
-    $this->logger->log(sprintf('Processando pedido %s.', $order_id));
+    $this->logger->order(sprintf('Processando pedido %s.', $order_id));
     $order   = wc_get_order($order_id);
     $payment = new VindiPaymentProcessor($order, $this, $this->vindi_settings, $this->controllers);
 
@@ -246,7 +246,7 @@ abstract class VindiPaymentGateway extends WC_Payment_Gateway_CC
 
       $result = $this->refund_transaction($bill_id, $amount, $reason);
 
-      $this->logger->log('Resultado do reembolso: ' . wc_print_r($result, true));
+      $this->logger->order('Resultado do reembolso: ' . wc_print_r($result, true));
       switch (strtolower($result['status'])) {
         case 'success':
           $order->add_order_note(

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -340,7 +340,7 @@ class VindiPaymentProcessor
                     $this->abort(__($message, VINDI), true);
                 }
             } catch (Exception $err) {
-                $this->logger->log(sprintf('Deu erro na criação da conta %s', $single_payment_bill));
+                $this->logger->customer(sprintf('Deu erro na criação da conta %s', $single_payment_bill));
                 $this->abort(__('Não foi possível criar o pedido.', VINDI), true);
             }
         }
@@ -1054,7 +1054,7 @@ class VindiPaymentProcessor
         $bill = $this->routes->createBill($data);
 
         if (!$bill) {
-            $this->logger->log(sprintf('Erro no pagamento do pedido %s.', $this->order->id));
+            $this->logger->order(sprintf('Erro no pagamento do pedido %s.', $this->order->id));
             $message = sprintf(__('Pagamento Falhou. (%s)', VINDI), $this->vindi_settings->api->last_error);
             $this->order->update_status('failed', $message);
 
@@ -1062,7 +1062,7 @@ class VindiPaymentProcessor
         }
 
         if ($bill['id']) {
-            $this->logger->log(sprintf('Update Bill: %s', json_encode($bill)));
+            $this->logger->order(sprintf('Update Bill: %s', json_encode($bill)));
             update_post_meta($this->order->id, 'vindi_bill_id', $bill['id']);
         }
         return $bill;
@@ -1164,7 +1164,7 @@ class VindiPaymentProcessor
                 $status_message = __('Aguardando pagamento do pedido.', VINDI);
             }
             array_push($bills_status, $bill['status']);
-            $this->logger->log($data_to_log);
+            $this->logger->order($data_to_log);
         }
         if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();


### PR DESCRIPTION
# GitHub Issue #125 

## O que mudou
Adicionei novos tipos de logs para separar as informações de cada entidade do plugin, que antes eram salvos no mesmo arquivo.

## Motivação
Facilitar a visualização dos logs e evitar a criação de arquivos de logs duplicados, devido a grande quantidade de conteúdos adicionados. 

## Solução proposta
Separação dos logs de acordo com sua respectiva entidade: _product_, _plan_, _webhook_, _customer_ e _request_.
![logs](https://user-images.githubusercontent.com/71287681/195188186-c2418008-401a-4af5-a745-da678a044cbf.png)

## Como testar
Basta fazer qualquer ação e tentar visualizar os logs referentes a ela.
