### PR TITLE
Fix: utilização de coupons com free trial

### DIFF
--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -808,15 +808,18 @@ class VindiPaymentProcessor
             ),
         );
 
-        if (!empty($this->order->get_total_discount()) && $order_item['type'] == 'line_item') {
+        $coupons = array_values($this->vindi_settings->woocommerce->cart->get_coupons());
+        
+        if (!empty($coupons) && $order_item['type'] == 'line_item') {
             $product_item['discounts'] = [];
-            $coupons = array_values($this->vindi_settings->woocommerce->cart->get_coupons());
+
             foreach ($coupons as $coupon) {
                 if ($this->coupon_supports_product($order_item, $coupon)) {
                     $product_item['discounts'][] = $this->build_discount_item_for_subscription($coupon, $plan_cycles);
                 }
             }
-        }
+        } 
+
         return $product_item;
     }
 


### PR DESCRIPTION
# GitHub Issue #132 
**Essa PR depende da PR #122 para funcionar corretamente.**

## O que mudou
Utilização de coupons em assinaturas que possuem free trial.

## Motivação
Ao fazer uma compra com período grátis utilizando algum coupon de desconto, o valor do coupon não é descontado no valor da assinatura.
![Screenshot from 2022-12-21 08-41-20](https://user-images.githubusercontent.com/71287681/209208318-9d3cf068-5217-438e-b227-838c1db2158a.png)
![Screenshot from 2022-12-21 08-43-39](https://user-images.githubusercontent.com/71287681/209208349-54baedab-75ca-4bf2-8f68-33d09cc361b7.png)

## Solução proposta
Identifiquei que no plugin, havia uma verificação do valor descontado no pedido e, a partir disso era feito o lançamento dos valores de desconto. Alterei a verificação para verificar a existencia de coupon e a partir disso adicionar o desconto do mesmo.
![Screenshot from 2022-12-22 15-59-36](https://user-images.githubusercontent.com/71287681/209208646-834e989c-6ead-47ff-bbd7-c31397ffbf2e.png)

## Como testar
Fazer a compra de algum produto com free trial ativado.
