### PR TITLE
fix/duplicate_variable_plans

### DIFF
--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -52,19 +52,17 @@ class PlansController
       return;
     }
 
-        if ($this->check_plan_vindi_item_id($post_id, 'vindi_plan_id') > 1) {
-            update_post_meta($post_id, 'vindi_plan_id', '');
-        }
+    if ($this->check_plan_vindi_item_id($post_id, 'vindi_plan_id') > 1) {
+        update_post_meta($post_id, 'vindi_plan_id', '');
+    }
 
-        if ($this->check_plan_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-            update_post_meta($post_id, 'vindi_product_id', '');
-        }
+    if ($this->check_plan_vindi_item_id($post_id, 'vindi_product_id') > 1) {
+        update_post_meta($post_id, 'vindi_product_id', '');
+    }
 
     // Check if it's a new post
     // The $update value is unreliable because of the auto_draft functionality
-    if(!$recreated && get_post_status($post_id) != 'publish' || (
-      !empty(get_post_meta($post_id, 'vindi_plan_id', true)) &&
-      !empty(get_post_meta($post_id, 'vindi_product_id', true)))
+    if( !$recreated && get_post_status($post_id) != 'publish' || ( !empty(get_post_meta($post_id, 'vindi_plan_id', true ) ) )
     ) {
 
       return $this->update($post_id);
@@ -475,6 +473,8 @@ class PlansController
         global $wpdb;
         $vindi_id = get_post_meta($post_id, $meta, true);
 
+        if ( ! $vindi_id ) return 0;
+        
         $sql = "SELECT 
                   post_id as id 
                 FROM {$wpdb->prefix}postmeta

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -56,9 +56,9 @@ class ProductController
       return;
     }
 
-        if ($this->check_product_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-            update_post_meta($post_id, 'vindi_product_id', '');
-        }
+    if ($this->check_product_vindi_item_id($post_id, 'vindi_product_id') > 1) {
+        update_post_meta($post_id, 'vindi_product_id', '');
+    }
 
     // Check if it's a new post
     // The $update value is unreliable because of the auto_draft functionality
@@ -153,6 +153,8 @@ class ProductController
     {
         global $wpdb;
         $vindi_id = get_post_meta($post_id, $meta, true);
+
+        if ( ! $vindi_id ) return 0;
 
         $sql = "SELECT 
                   post_id as id 


### PR DESCRIPTION
## O que mudou
Correção da duplicação de produtos variáveis dentro do WooCommerce. 

## Motivação
Após a atualização de produtos variáveis duplicados o mesmo perdia seu vinculo com a Vindi.

## Solução proposta
Crrigir a verficação que sempre identificava a ação de salvamento do produto variável como criação e não como update.

## Como testar
Utilizar a função duplicar do WooCommerce para um produto variável.
