### PR TITLE
Atualização de compatibilidade do WC e PHP

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 6.3
 WC requires at least: 3.0.0
 WC tested up to: 7.6.0
 Requires PHP: 5.6
-Stable Tag: 1.2.5
+Stable Tag: 1.2.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,12 +39,16 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+
+= 1.2.6 - 28/02/2024 =
+-Lançamento da versão de patch.
+- **Melhoria:** Validação do plugins para as novas versões WooCommerce, WordPress e PHP
+
 = 1.2.5 - 12/10/2023 =
 -Lançamento da versão de patch.
 - **Correção:** Validação das depenências do plugin
 - **Correção:** Funcionamento da opção de sincronismo de assinaturas
 
-== Changelog ==
 = 1.2.4 - 30/08/2023 =
 -Lançamento da versão de patch.
 - **Correção:** Removido campo de seleção de parcelas para produtos sem parcelamento

--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -193,7 +193,7 @@ class WcVindiPayment extends AbstractInstance
    */
     public function filter_woocommerce_cart_needs_payment($needs_payment, $cart)
     {
-        if (floatval($cart->total) == 0 && $this->cart_has_trial($cart)) {
+        if (floatval($cart->total) == 0 || $this->cart_has_trial($cart)) {
             return true;
         }
 

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -154,7 +154,7 @@ class CustomerController
         'phone_type' => 'mobile',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_meta('billing_cellphone'))
       );
-      if ($vindi_phones['mobile']) $mobile['id'] = $vindi_phones['mobile'];
+      if (isset($vindi_phones['mobile'])) $mobile['id'] = $vindi_phones['mobile'];
       $phones[] = $mobile;
     }
     if ($customer->get_billing_phone()) {
@@ -162,7 +162,7 @@ class CustomerController
         'phone_type' => 'landline',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_billing_phone())
       );
-      if ($vindi_phones['landline']) $landline['id'] = $vindi_phones['landline'];
+      if (isset($vindi_phones['landline'])) $landline['id'] = $vindi_phones['landline'];
       $phones[] = $landline;
     }
 

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -109,9 +109,9 @@ class CustomerController
       )
     );
 
-          if (isset($createdUser['id']) && $createdUser['id']) {
-            update_user_meta($user_id, 'vindi_customer_id', $createdUser['id']);
-          }
+    if (isset($createdUser['id']) && $createdUser['id']) {
+      update_user_meta($user_id, 'vindi_customer_id', $createdUser['id']);
+    }
 
     return $createdUser;
   }

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -155,7 +155,7 @@ class CustomerController
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_meta('billing_cellphone'))
       );
                 if (isset($vindi_phones['mobile'])) {
-                  $mobile['id'] = $vindi_phones['mobile'];
+                    $mobile['id'] = $vindi_phones['mobile'];
                 }
       $phones[] = $mobile;
     }
@@ -164,9 +164,9 @@ class CustomerController
         'phone_type' => 'landline',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_billing_phone())
       );
-                  if (isset($vindi_phones['landline'])) { 
+                if (isset($vindi_phones['landline'])) { 
                     $landline['id'] = $vindi_phones['landline'];
-                  }
+                }
       $phones[] = $landline;
     }
 

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -126,24 +126,19 @@ class CustomerController
 
   function update($user_id, $order = null)
   {
-
     $vindi_customer_id = get_user_meta($user_id, 'vindi_customer_id', true);
-
     // Check meta Vindi ID
     if (empty($vindi_customer_id)) {
 
       return $this->create($user_id, $order);
     }
-
     // Check user exists in Vindi
     $vindiUser = $this->routes->findCustomerById($vindi_customer_id);
     if (!$vindiUser) {
 
       return $this->create($user_id);
     }
-
     $customer = new WC_Customer($user_id);
-
     $user = $customer->get_data();
     $phones = $vindi_phones = [];
     foreach ($vindiUser['phones'] as $phone) {
@@ -174,7 +169,6 @@ class CustomerController
     $notes = null;
     $cpf_or_cnpj = null;
     $metadata = null;
-
 
     if ($order && method_exists($order, 'needs_payment')) {
       $metadata = array();
@@ -226,7 +220,6 @@ class CustomerController
     );
     return $updatedUser;
   }
-
 
   /**
    * When a user is deleted within the WP, it is reflected in the Vindi.

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -164,7 +164,7 @@ class CustomerController
         'phone_type' => 'landline',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_billing_phone())
       );
-                if (isset($vindi_phones['landline'])) { 
+                if (isset($vindi_phones['landline'])) {
                     $landline['id'] = $vindi_phones['landline'];
                 }
       $phones[] = $landline;

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -109,9 +109,9 @@ class CustomerController
       )
     );
 
-    if (isset($createdUser['id']) && $createdUser['id']) {
-      update_user_meta($user_id, 'vindi_customer_id', $createdUser['id']);
-    }
+          if (isset($createdUser['id']) && $createdUser['id']) {
+            update_user_meta($user_id, 'vindi_customer_id', $createdUser['id']);
+          }
 
     return $createdUser;
   }
@@ -154,7 +154,9 @@ class CustomerController
         'phone_type' => 'mobile',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_meta('billing_cellphone'))
       );
-      if (isset($vindi_phones['mobile'])) $mobile['id'] = $vindi_phones['mobile'];
+                if (isset($vindi_phones['mobile'])) {
+                  $mobile['id'] = $vindi_phones['mobile'];
+                }
       $phones[] = $mobile;
     }
     if ($customer->get_billing_phone()) {
@@ -162,7 +164,9 @@ class CustomerController
         'phone_type' => 'landline',
         'number' => preg_replace('/\D+/', '', '55' . $customer->get_billing_phone())
       );
-      if (isset($vindi_phones['landline'])) $landline['id'] = $vindi_phones['landline'];
+                  if (isset($vindi_phones['landline'])) { 
+                    $landline['id'] = $vindi_phones['landline'];
+                  }
       $phones[] = $landline;
     }
 

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -55,147 +55,67 @@ class PlansController
   function create($post_id, $post, $update, $recreated = false)
   {
 
-        // Check if the post is a draft
-        if (strpos(get_post_status($post_id), 'draft') !== false) {
-          return;
+    // Check if the post is a draft
+    if (strpos(get_post_status($post_id), 'draft') !== false) {
+      return;
+    }
+    // Check if the post is product
+    if (get_post_type($post_id) != 'product') {
+      return;
+    }
+
+    $post_meta = new PostMeta();
+    if ($post_meta->check_vindi_item_id($post_id, 'vindi_plan_id') > 1) {
+      update_post_meta($post_id, 'vindi_plan_id', '');
+    }
+
+    if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
+      update_post_meta($post_id, 'vindi_product_id', '');
+    }
+
+    // Check if it's a new post
+    // The $update value is unreliable because of the auto_draft functionality
+    if (
+      !$recreated && get_post_status($post_id) != 'publish' ||
+      (!empty(get_post_meta($post_id, 'vindi_plan_id', true)))
+    ) {
+
+      return $this->update($post_id);
+    }
+
+    $product = wc_get_product($post_id);
+
+    // Check if the post is of the subscription type
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
+      return;
+    }
+
+    // Checks if the plan is a variation and creates it
+    if ($product->get_type() == 'variable-subscription') {
+
+      $variations = $product->get_available_variations();
+      $variations_products = $variations_plans = [];
+
+      foreach ($variations as $variation) {
+        $variation_product = wc_get_product($variation['variation_id']);
+
+        $data = $variation_product->get_data();
+
+        $interval_type     = $variation_product->get_meta('_subscription_period');
+        $interval_count    = $variation_product->get_meta('_subscription_period_interval');
+        $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
+        $variation_id      = $variation['variation_id'];
+
+        $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+
+        if (!$plan_installments || $plan_installments === 0) {
+          $plan_installments = 1;
         }
-        // Check if the post is product
-        if (get_post_type($post_id) != 'product') {
-          return;
-        }
-
-        $post_meta = new PostMeta();
-        if ($post_meta->check_vindi_item_id($post_id, 'vindi_plan_id') > 1) {
-          update_post_meta($post_id, 'vindi_plan_id', '');
-        }
-
-        if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-          update_post_meta($post_id, 'vindi_product_id', '');
-        }
-
-        // Check if it's a new post
-        // The $update value is unreliable because of the auto_draft functionality
-        if (
-          !$recreated && get_post_status($post_id) != 'publish' ||
-          (!empty(get_post_meta($post_id, 'vindi_plan_id', true)))
-        ) {
-
-          return $this->update($post_id);
-        }
-
-        $product = wc_get_product($post_id);
-
-        // Check if the post is of the subscription type
-        if (!in_array($product->get_type(), $this->allowedTypes)) {
-          return;
-        }
-
-        // Checks if the plan is a variation and creates it
-        if ($product->get_type() == 'variable-subscription') {
-
-          $variations = $product->get_available_variations();
-          $variations_products = $variations_plans = [];
-
-          foreach ($variations as $variation) {
-            $variation_product = wc_get_product($variation['variation_id']);
-
-            $data = $variation_product->get_data();
-
-            $interval_type     = $variation_product->get_meta('_subscription_period');
-            $interval_count    = $variation_product->get_meta('_subscription_period_interval');
-            $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
-            $variation_id      = $variation['variation_id'];
-
-            $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
-
-            if (!$plan_installments || $plan_installments === 0) {
-              $plan_installments = 1;
-            }
-
-            $trigger_day = VindiConversions::convertTriggerToDay(
-              $product->get_meta('_subscription_trial_length'),
-              $product->get_meta('_subscription_trial_period')
-            );
-
-            // Creates the product within the Vindi
-            $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
-            $createdProduct = !empty($vindi_product_id) ?
-              $this->routes->findProductById($vindi_product_id) :
-              $this->routes->createProduct(
-                array(
-                  'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-                  'code' => 'WC-' . $data['id'],
-                  'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-                  'invoice' => 'always',
-                  'pricing_schema' => array(
-                    'price' => ($data['price']) ? $data['price'] : 0,
-                    'schema_type' => 'flat',
-                  )
-                )
-              );
-
-            // Creates the plan within the Vindi
-            $createdPlan = $this->routes->createPlan(array(
-              'name' => VINDI_PREFIX_PLAN . $data['name'],
-              'interval' => $plan_interval['interval'],
-              'interval_count' => $plan_interval['interval_count'],
-              'billing_trigger_type' => 'beginning_of_period',
-              'billing_trigger_day' => $trigger_day,
-              'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
-              'code' => 'WC-' . $data['id'],
-              'installments' => $plan_installments,
-              'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-              'plan_items' => array(
-                ($product->get_meta('_subscription_length') == 0) ? array(
-                  'product_id' => $createdProduct['id']
-                ) : array(
-                  'cycles' => $product->get_meta('_subscription_length'),
-                  'product_id' => $createdProduct['id']
-                )
-              ),
-            ));
-            $variations_products[$variation['variation_id']] = $createdProduct;
-            $variations_plans[$variation['variation_id']] = $createdPlan;
-
-            // Saving product id and plan in the WC goal
-            if (isset($variation['variation_id']) && $createdProduct['id']) {
-              update_post_meta($variation['variation_id'], 'vindi_product_id', $createdProduct['id']);
-            }
-
-            if (isset($variation['variation_id']) && $createdPlan['id']) {
-              update_post_meta($variation['variation_id'], 'vindi_plan_id', $createdPlan['id']);
-            }
-          }
-
-          $product_id = end($variations_products)['id'];
-
-          if ($product_id) {
-            update_post_meta($post_id, 'vindi_product_id', end($variations_products)['id']);
-            update_post_meta($post_id, 'vindi_plan_id', end($variations_products)['id']);
-          }
-
-          return array(
-            'product' => $variations_products,
-            'plan' => $variations_plans,
-          );
-        }
-
-        $data = $product->get_data();
-
-
-        $interval_type = $product->get_meta('_subscription_period');
-        $interval_count = $product->get_meta('_subscription_period_interval');
-        $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
 
         $trigger_day = VindiConversions::convertTriggerToDay(
           $product->get_meta('_subscription_trial_length'),
           $product->get_meta('_subscription_trial_period')
         );
-
-        $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
-        if (!$plan_installments || $plan_installments === 0) {
-          $plan_installments = 1;
-        }
 
         // Creates the product within the Vindi
         $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
@@ -234,28 +154,108 @@ class PlansController
             )
           ),
         ));
-
+        $variations_products[$variation['variation_id']] = $createdProduct;
+        $variations_plans[$variation['variation_id']] = $createdPlan;
 
         // Saving product id and plan in the WC goal
-        if ($createdProduct && isset($createdProduct['id'])) {
-          update_post_meta($post_id, 'vindi_product_id', $createdProduct['id']);
-        }
-        if ($createdPlan && isset($createdPlan['id'])) {
-          update_post_meta($post_id, 'vindi_plan_id', $createdPlan['id']);
+        if (isset($variation['variation_id']) && $createdProduct['id']) {
+          update_post_meta($variation['variation_id'], 'vindi_product_id', $createdProduct['id']);
         }
 
-        if ($createdPlan && $createdProduct) {
-          set_transient('vindi_product_message', 'created', 60);
-        } else {
-          set_transient('vindi_product_message', 'error', 60);
+        if (isset($variation['variation_id']) && $createdPlan['id']) {
+          update_post_meta($variation['variation_id'], 'vindi_plan_id', $createdPlan['id']);
         }
+      }
 
-        $response = array(
-          'product' => $createdProduct,
-          'plan' => $createdPlan,
-        );
+      $product_id = end($variations_products)['id'];
 
-        return $response;
+      if ($product_id) {
+        update_post_meta($post_id, 'vindi_product_id', end($variations_products)['id']);
+        update_post_meta($post_id, 'vindi_plan_id', end($variations_products)['id']);
+      }
+
+      return array(
+        'product' => $variations_products,
+        'plan' => $variations_plans,
+      );
+    }
+
+    $data = $product->get_data();
+
+
+    $interval_type = $product->get_meta('_subscription_period');
+    $interval_count = $product->get_meta('_subscription_period_interval');
+    $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
+
+    $trigger_day = VindiConversions::convertTriggerToDay(
+      $product->get_meta('_subscription_trial_length'),
+      $product->get_meta('_subscription_trial_period')
+    );
+
+    $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
+    if (!$plan_installments || $plan_installments === 0) {
+      $plan_installments = 1;
+    }
+
+    // Creates the product within the Vindi
+    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
+    $createdProduct = !empty($vindi_product_id) ?
+      $this->routes->findProductById($vindi_product_id) :
+      $this->routes->createProduct(
+        array(
+          'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+          'code' => 'WC-' . $data['id'],
+          'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+          'invoice' => 'always',
+          'pricing_schema' => array(
+            'price' => ($data['price']) ? $data['price'] : 0,
+            'schema_type' => 'flat',
+          )
+        )
+      );
+
+    // Creates the plan within the Vindi
+    $createdPlan = $this->routes->createPlan(array(
+      'name' => VINDI_PREFIX_PLAN . $data['name'],
+      'interval' => $plan_interval['interval'],
+      'interval_count' => $plan_interval['interval_count'],
+      'billing_trigger_type' => 'beginning_of_period',
+      'billing_trigger_day' => $trigger_day,
+      'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
+      'code' => 'WC-' . $data['id'],
+      'installments' => $plan_installments,
+      'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+      'plan_items' => array(
+        ($product->get_meta('_subscription_length') == 0) ? array(
+          'product_id' => $createdProduct['id']
+        ) : array(
+          'cycles' => $product->get_meta('_subscription_length'),
+          'product_id' => $createdProduct['id']
+        )
+      ),
+    ));
+
+
+    // Saving product id and plan in the WC goal
+    if ($createdProduct && isset($createdProduct['id'])) {
+      update_post_meta($post_id, 'vindi_product_id', $createdProduct['id']);
+    }
+    if ($createdPlan && isset($createdPlan['id'])) {
+      update_post_meta($post_id, 'vindi_plan_id', $createdPlan['id']);
+    }
+
+    if ($createdPlan && $createdProduct) {
+      set_transient('vindi_product_message', 'created', 60);
+    } else {
+      set_transient('vindi_product_message', 'error', 60);
+    }
+
+    $response = array(
+      'product' => $createdProduct,
+      'plan' => $createdPlan,
+    );
+
+    return $response;
   }
 
   function update($post_id)
@@ -427,38 +427,38 @@ class PlansController
    */
   function trash($post_id)
   {
-        // Check if the post is product
-        if (get_post_type($post_id) != 'product') {
-          return;
-        }
+    // Check if the post is product
+    if (get_post_type($post_id) != 'product') {
+      return;
+    }
 
-        $product = wc_get_product($post_id);
-        // Check if the post is of the signature type
-        if (!in_array($product->get_type(), $this->allowedTypes)) {
-          return;
-        }
+    $product = wc_get_product($post_id);
+    // Check if the post is of the signature type
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
+      return;
+    }
 
-        $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
-        $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
+    $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
+    $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
 
-        if (empty($vindi_product_id) || empty($vindi_plan_id)) {
-          return;
-        }
+    if (empty($vindi_product_id) || empty($vindi_plan_id)) {
+      return;
+    }
 
-        // Changes the product status within the Vindi
-        $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-          'status' => 'inactive',
-        ));
+    // Changes the product status within the Vindi
+    $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+      'status' => 'inactive',
+    ));
 
-        // Changes the plan status within the Vindi
-        $inactivatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
-          'status' => 'inactive',
-        ));
+    // Changes the plan status within the Vindi
+    $inactivatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
+      'status' => 'inactive',
+    ));
 
-        return array(
-          'product' => $inactivatedProduct,
-          'plan' => $inactivatedPlan,
-        );
+    return array(
+      'product' => $inactivatedProduct,
+      'plan' => $inactivatedPlan,
+    );
   }
 
   /**
@@ -469,37 +469,37 @@ class PlansController
    */
   function untrash($post_id)
   {
-        // Check if the post is product
-        if (get_post_type($post_id) != 'product') {
-          return;
-        }
+    // Check if the post is product
+    if (get_post_type($post_id) != 'product') {
+      return;
+    }
 
-        $product = wc_get_product($post_id);
-        // Check if the post is of the signature type
-        if (!in_array($product->get_type(), $this->allowedTypes)) {
-          return;
-        }
+    $product = wc_get_product($post_id);
+    // Check if the post is of the signature type
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
+      return;
+    }
 
-        $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
-        $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
+    $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
+    $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
 
-        if (empty($vindi_product_id) || empty($vindi_plan_id)) {
-          return;
-        }
+    if (empty($vindi_product_id) || empty($vindi_plan_id)) {
+      return;
+    }
 
-        // Changes the product status within the Vindi
-        $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-          'status' => 'active',
-        ));
+    // Changes the product status within the Vindi
+    $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+      'status' => 'active',
+    ));
 
-        // Changes the plan status within the Vindi
-        $activatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
-          'status' => 'active',
-        ));
+    // Changes the plan status within the Vindi
+    $activatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
+      'status' => 'active',
+    ));
 
-        return array(
-          'product' => $activatedProduct,
-          'plan' => $activatedPlan,
-        );
+    return array(
+      'product' => $activatedProduct,
+      'plan' => $activatedPlan,
+    );
   }
 }

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -75,8 +75,8 @@ class PlansController
 
     // Check if it's a new post
     // The $update value is unreliable because of the auto_draft functionality
-    $post_status = get_post_status($post_id);
-    $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id', true);
+        $post_status = get_post_status($post_id);
+        $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id', true);
 
         if (!$recreated && $post_status != 'publish') {
             if (!empty($vindi_plan_id)) {
@@ -124,11 +124,11 @@ class PlansController
           $this->routes->findProductById($vindi_product_id) :
                       $this->routes->createProduct(
                       array(
-                        'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-                        'code' => 'WC-' . $data['id'],
-                        'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-                        'invoice' => 'always',
-                        'pricing_schema' => array(
+                          'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+                          'code' => 'WC-' . $data['id'],
+                          'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+                          'invoice' => 'always',
+                          'pricing_schema' => array(
                           'price' => ($data['price']) ? $data['price'] : 0,
                           'schema_type' => 'flat',
                         )

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -15,30 +15,30 @@ class PlansController
 {
   /**
    * @var array
-   */
-  private $types;
+  */
+    private $types;
 
   /**
    * @var VindiRoutes
-   */
-  private $routes;
+  */
+    private $routes;
 
   /**
    * @var VindiLogger
-   */
-  private $logger;
+  */
+    private $logger;
 
   /**
    * @var array
-   */
-  private $allowed_types;
+  */
+    private $allowedTypes;
 
   function __construct(VindiSettings $vindi_settings)
   {
     $this->routes = $vindi_settings->routes;
     $this->logger = $vindi_settings->logger;
 
-    $this->allowed_types = array('variable-subscription', 'subscription');
+    $this->allowedTypes = array('variable-subscription', 'subscription');
 
     add_action('wp_insert_post', array($this, 'create'), 10, 3);
     add_action('wp_trash_post', array($this, 'trash'), 10, 1);
@@ -86,7 +86,7 @@ class PlansController
     $product = wc_get_product($post_id);
 
     // Check if the post is of the subscription type
-    if (!in_array($product->get_type(), $this->allowed_types)) {
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
       return;
     }
 
@@ -262,7 +262,7 @@ class PlansController
     $product = wc_get_product($post_id);
 
     // Check if the post is of the signature type
-    if (!in_array($product->get_type(), $this->allowed_types)) {
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
       return;
     }
 
@@ -434,7 +434,7 @@ class PlansController
 
     $product = wc_get_product($post_id);
     // Check if the post is of the signature type
-    if (!in_array($product->get_type(), $this->allowed_types)) {
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
       return;
     }
 
@@ -476,7 +476,7 @@ class PlansController
 
     $product = wc_get_product($post_id);
     // Check if the post is of the signature type
-    if (!in_array($product->get_type(), $this->allowed_types)) {
+    if (!in_array($product->get_type(), $this->allowedTypes)) {
       return;
     }
 

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -15,29 +15,28 @@ class PlansController
 {
   /**
    * @var array
-  */
-    private $types;
+   */
+  private $types;
 
   /**
    * @var VindiRoutes
-  */
-    private $routes;
+   */
+  private $routes;
 
   /**
    * @var VindiLogger
-  */
-    private $logger;
+   */
+  private $logger;
 
   /**
    * @var array
-  */
-    private $allowedTypes;
+   */
+  private $allowedTypes;
 
   function __construct(VindiSettings $vindi_settings)
   {
     $this->routes = $vindi_settings->routes;
     $this->logger = $vindi_settings->logger;
-
     $this->allowedTypes = array('variable-subscription', 'subscription');
 
     add_action('wp_insert_post', array($this, 'create'), 10, 3);
@@ -55,83 +54,165 @@ class PlansController
    */
   function create($post_id, $post, $update, $recreated = false)
   {
-    
-    // Check if the post is a draft
-    if (strpos(get_post_status($post_id), 'draft') !== false) {
-      return;
-    }
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
+
+        // Check if the post is a draft
+        if (strpos(get_post_status($post_id), 'draft') !== false) {
+          return;
+        }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
 
         $post_meta = new PostMeta();
         if ($post_meta->check_vindi_item_id($post_id, 'vindi_plan_id') > 1) {
-            update_post_meta($post_id, 'vindi_plan_id', '');
+          update_post_meta($post_id, 'vindi_plan_id', '');
         }
 
         if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-            update_post_meta($post_id, 'vindi_product_id', '');
+          update_post_meta($post_id, 'vindi_product_id', '');
         }
 
-    // Check if it's a new post
-    // The $update value is unreliable because of the auto_draft functionality
-        if (!$recreated && get_post_status($post_id) != 'publish'||
-        (!empty(get_post_meta($post_id, 'vindi_plan_id', true)))
+        // Check if it's a new post
+        // The $update value is unreliable because of the auto_draft functionality
+        if (
+          !$recreated && get_post_status($post_id) != 'publish' ||
+          (!empty(get_post_meta($post_id, 'vindi_plan_id', true)))
         ) {
 
           return $this->update($post_id);
         }
 
-    $product = wc_get_product($post_id);
+        $product = wc_get_product($post_id);
 
-    // Check if the post is of the subscription type
-    if (!in_array($product->get_type(), $this->allowedTypes)) {
-      return;
-    }
+        // Check if the post is of the subscription type
+        if (!in_array($product->get_type(), $this->allowedTypes)) {
+          return;
+        }
 
-    // Checks if the plan is a variation and creates it
-    if ($product->get_type() == 'variable-subscription') {
+        // Checks if the plan is a variation and creates it
+        if ($product->get_type() == 'variable-subscription') {
 
-      $variations = $product->get_available_variations();
-      $variations_products = $variations_plans = [];
+          $variations = $product->get_available_variations();
+          $variations_products = $variations_plans = [];
 
-      foreach ($variations as $variation) {
-        $variation_product = wc_get_product($variation['variation_id']);
+          foreach ($variations as $variation) {
+            $variation_product = wc_get_product($variation['variation_id']);
 
-        $data = $variation_product->get_data();
+            $data = $variation_product->get_data();
 
-        $interval_type     = $variation_product->get_meta('_subscription_period');
-        $interval_count    = $variation_product->get_meta('_subscription_period_interval');
-        $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
-                $variation_id      = $variation['variation_id'];
-        
-                $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+            $interval_type     = $variation_product->get_meta('_subscription_period');
+            $interval_count    = $variation_product->get_meta('_subscription_period_interval');
+            $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
+            $variation_id      = $variation['variation_id'];
 
-                if (!$plan_installments || $plan_installments === 0) {
-                    $plan_installments = 1;
-                }
+            $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+
+            if (!$plan_installments || $plan_installments === 0) {
+              $plan_installments = 1;
+            }
+
+            $trigger_day = VindiConversions::convertTriggerToDay(
+              $product->get_meta('_subscription_trial_length'),
+              $product->get_meta('_subscription_trial_period')
+            );
+
+            // Creates the product within the Vindi
+            $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
+            $createdProduct = !empty($vindi_product_id) ?
+              $this->routes->findProductById($vindi_product_id) :
+              $this->routes->createProduct(
+                array(
+                  'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+                  'code' => 'WC-' . $data['id'],
+                  'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+                  'invoice' => 'always',
+                  'pricing_schema' => array(
+                    'price' => ($data['price']) ? $data['price'] : 0,
+                    'schema_type' => 'flat',
+                  )
+                )
+              );
+
+            // Creates the plan within the Vindi
+            $createdPlan = $this->routes->createPlan(array(
+              'name' => VINDI_PREFIX_PLAN . $data['name'],
+              'interval' => $plan_interval['interval'],
+              'interval_count' => $plan_interval['interval_count'],
+              'billing_trigger_type' => 'beginning_of_period',
+              'billing_trigger_day' => $trigger_day,
+              'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
+              'code' => 'WC-' . $data['id'],
+              'installments' => $plan_installments,
+              'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+              'plan_items' => array(
+                ($product->get_meta('_subscription_length') == 0) ? array(
+                  'product_id' => $createdProduct['id']
+                ) : array(
+                  'cycles' => $product->get_meta('_subscription_length'),
+                  'product_id' => $createdProduct['id']
+                )
+              ),
+            ));
+            $variations_products[$variation['variation_id']] = $createdProduct;
+            $variations_plans[$variation['variation_id']] = $createdPlan;
+
+            // Saving product id and plan in the WC goal
+            if (isset($variation['variation_id']) && $createdProduct['id']) {
+              update_post_meta($variation['variation_id'], 'vindi_product_id', $createdProduct['id']);
+            }
+
+            if (isset($variation['variation_id']) && $createdPlan['id']) {
+              update_post_meta($variation['variation_id'], 'vindi_plan_id', $createdPlan['id']);
+            }
+          }
+
+          $product_id = end($variations_products)['id'];
+
+          if ($product_id) {
+            update_post_meta($post_id, 'vindi_product_id', end($variations_products)['id']);
+            update_post_meta($post_id, 'vindi_plan_id', end($variations_products)['id']);
+          }
+
+          return array(
+            'product' => $variations_products,
+            'plan' => $variations_plans,
+          );
+        }
+
+        $data = $product->get_data();
+
+
+        $interval_type = $product->get_meta('_subscription_period');
+        $interval_count = $product->get_meta('_subscription_period_interval');
+        $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
 
         $trigger_day = VindiConversions::convertTriggerToDay(
-                        $product->get_meta('_subscription_trial_length'),
-                        $product->get_meta('_subscription_trial_period')
-                      );
+          $product->get_meta('_subscription_trial_length'),
+          $product->get_meta('_subscription_trial_period')
+        );
+
+        $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
+        if (!$plan_installments || $plan_installments === 0) {
+          $plan_installments = 1;
+        }
 
         // Creates the product within the Vindi
         $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
         $createdProduct = !empty($vindi_product_id) ?
           $this->routes->findProductById($vindi_product_id) :
-          $this->routes->createProduct(array(
-            'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-            'code' => 'WC-' . $data['id'],
-            'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-            'invoice' => 'always',
-            'pricing_schema' => array(
-              'price' => ($data['price']) ? $data['price'] : 0,
-              'schema_type' => 'flat',
+          $this->routes->createProduct(
+            array(
+              'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+              'code' => 'WC-' . $data['id'],
+              'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+              'invoice' => 'always',
+              'pricing_schema' => array(
+                'price' => ($data['price']) ? $data['price'] : 0,
+                'schema_type' => 'flat',
+              )
             )
-          )
-        );
+          );
 
         // Creates the plan within the Vindi
         $createdPlan = $this->routes->createPlan(array(
@@ -142,7 +223,7 @@ class PlansController
           'billing_trigger_day' => $trigger_day,
           'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
           'code' => 'WC-' . $data['id'],
-                      'installments' => $plan_installments,
+          'installments' => $plan_installments,
           'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
           'plan_items' => array(
             ($product->get_meta('_subscription_length') == 0) ? array(
@@ -153,108 +234,28 @@ class PlansController
             )
           ),
         ));
-        $variations_products[$variation['variation_id']] = $createdProduct;
-        $variations_plans[$variation['variation_id']] = $createdPlan;
-
-                      // Saving product id and plan in the WC goal
-                      if (isset($variation['variation_id']) && $createdProduct['id']) {
-                          update_post_meta( $variation['variation_id'], 'vindi_product_id', $createdProduct['id'] );
-                      }
-
-                        if (isset($variation['variation_id']) && $createdPlan['id']) {
-                            update_post_meta( $variation['variation_id'], 'vindi_plan_id', $createdPlan['id'] );
-                        }
-
-      }
-
-            $product_id = end($variations_products)['id'];
-      
-            if ($product_id) {
-                update_post_meta( $post_id, 'vindi_product_id', end($variations_products)['id'] );
-                update_post_meta( $post_id, 'vindi_plan_id', end($variations_products)['id'] );
-            }
-
-      return array(
-        'product' => $variations_products,
-        'plan' => $variations_plans,
-      );
-    }
-
-    $data = $product->get_data();
 
 
-    $interval_type = $product->get_meta('_subscription_period');
-    $interval_count = $product->get_meta('_subscription_period_interval');
-    $plan_interval = VindiConversions::convert_interval($interval_count, $interval_type);
+        // Saving product id and plan in the WC goal
+        if ($createdProduct && isset($createdProduct['id'])) {
+          update_post_meta($post_id, 'vindi_product_id', $createdProduct['id']);
+        }
+        if ($createdPlan && isset($createdPlan['id'])) {
+          update_post_meta($post_id, 'vindi_plan_id', $createdPlan['id']);
+        }
 
-    $trigger_day = VindiConversions::convertTriggerToDay(
-      $product->get_meta('_subscription_trial_length'),
-      $product->get_meta('_subscription_trial_period')
-    );
+        if ($createdPlan && $createdProduct) {
+          set_transient('vindi_product_message', 'created', 60);
+        } else {
+          set_transient('vindi_product_message', 'error', 60);
+        }
 
-          $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
-          if (!$plan_installments || $plan_installments === 0) {
-              $plan_installments = 1;
-          }
+        $response = array(
+          'product' => $createdProduct,
+          'plan' => $createdPlan,
+        );
 
-    // Creates the product within the Vindi
-    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
-    $createdProduct = !empty($vindi_product_id) ?
-      $this->routes->findProductById($vindi_product_id) :
-      $this->routes->createProduct(array(
-        'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-        'code' => 'WC-' . $data['id'],
-        'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-        'invoice' => 'always',
-        'pricing_schema' => array(
-          'price' => ($data['price']) ? $data['price'] : 0,
-          'schema_type' => 'flat',
-        )
-      )
-    );
-
-    // Creates the plan within the Vindi
-    $createdPlan = $this->routes->createPlan(array(
-      'name' => VINDI_PREFIX_PLAN . $data['name'],
-      'interval' => $plan_interval['interval'],
-      'interval_count' => $plan_interval['interval_count'],
-      'billing_trigger_type' => 'beginning_of_period',
-      'billing_trigger_day' => $trigger_day,
-      'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
-      'code' => 'WC-' . $data['id'],
-          'installments' => $plan_installments,
-      'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-      'plan_items' => array(
-        ($product->get_meta('_subscription_length') == 0) ? array(
-          'product_id' => $createdProduct['id']
-        ) : array(
-          'cycles' => $product->get_meta('_subscription_length'),
-          'product_id' => $createdProduct['id']
-        )
-      ),
-    ));
-
-    
-    // Saving product id and plan in the WC goal
-          if ($createdProduct && isset($createdProduct['id'])) {
-            update_post_meta( $post_id, 'vindi_product_id', $createdProduct['id'] );
-          }
-            if ($createdPlan && isset($createdPlan['id'])) {
-              update_post_meta( $post_id, 'vindi_plan_id', $createdPlan['id'] );
-            }
-    
-    if ($createdPlan && $createdProduct) {
-      set_transient('vindi_product_message', 'created', 60);
-    } else {
-      set_transient('vindi_product_message', 'error', 60);
-    }
-
-    $response = array(
-      'product' => $createdProduct,
-      'plan' => $createdPlan,
-    );
-    
-    return $response;
+        return $response;
   }
 
   function update($post_id)
@@ -275,7 +276,6 @@ class PlansController
 
         return $this->create($post_id, '', '', true);
       }
-
     }
 
     // Checks if the plan is a variation and creates it
@@ -302,18 +302,18 @@ class PlansController
         $interval_type     = $variation_product->get_meta('_subscription_period');
         $interval_count    = $variation_product->get_meta('_subscription_period_interval');
         $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
-                $variation_id      = $variation['variation_id'];
-        
-                $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+        $variation_id      = $variation['variation_id'];
 
-                if (!$plan_installments || $plan_installments === 0) {
-                    $plan_installments = 1;
-                }
+        $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+
+        if (!$plan_installments || $plan_installments === 0) {
+          $plan_installments = 1;
+        }
 
         $trigger_day = VindiConversions::convertTriggerToDay(
-                        $product->get_meta('_subscription_trial_length'),
-                        $product->get_meta('_subscription_trial_period')
-                      );
+          $product->get_meta('_subscription_trial_length'),
+          $product->get_meta('_subscription_trial_period')
+        );
 
         // Updates the product within the Vindi
         $updatedProduct = $this->routes->updateProduct(
@@ -341,7 +341,7 @@ class PlansController
             'billing_trigger_day' => $trigger_day,
             'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
             'code' => 'WC-' . $data['id'],
-                      'installments' => $plan_installments,
+            'installments' => $plan_installments,
             'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
           )
         );
@@ -385,10 +385,10 @@ class PlansController
     );
 
     $vindi_plan_id     = get_post_meta($post_id, 'vindi_plan_id', true);
-          $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
-          if (!$plan_installments || $plan_installments === 0) {
-              $plan_installments = 1;
-          }
+    $plan_installments = $product->get_meta("vindi_max_credit_installments_$post_id");
+    if (!$plan_installments || $plan_installments === 0) {
+      $plan_installments = 1;
+    }
 
     // Updates the plan within the Vindi
     $updatedPlan = $this->routes->updatePlan(
@@ -401,7 +401,7 @@ class PlansController
         'billing_trigger_day' => $trigger_day,
         'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
         'code' => 'WC-' . $data['id'],
-            'installments' => $plan_installments,
+        'installments' => $plan_installments,
         'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
       )
     );
@@ -415,7 +415,7 @@ class PlansController
       'product' => $updatedProduct,
       'plan' => $updatedPlan,
     );
-    
+
     return $response;
   }
 
@@ -427,38 +427,38 @@ class PlansController
    */
   function trash($post_id)
   {
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
 
-    $product = wc_get_product($post_id);
-    // Check if the post is of the signature type
-    if (!in_array($product->get_type(), $this->allowedTypes)) {
-      return;
-    }
+        $product = wc_get_product($post_id);
+        // Check if the post is of the signature type
+        if (!in_array($product->get_type(), $this->allowedTypes)) {
+          return;
+        }
 
-    $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
-    $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
+        $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
+        $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
 
-    if (empty($vindi_product_id) || empty($vindi_plan_id)) {
-      return;
-    }
+        if (empty($vindi_product_id) || empty($vindi_plan_id)) {
+          return;
+        }
 
-    // Changes the product status within the Vindi
-    $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-      'status' => 'inactive',
-    ));
+        // Changes the product status within the Vindi
+        $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+          'status' => 'inactive',
+        ));
 
-    // Changes the plan status within the Vindi
-    $inactivatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
-      'status' => 'inactive',
-    ));
+        // Changes the plan status within the Vindi
+        $inactivatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
+          'status' => 'inactive',
+        ));
 
-    return array(
-      'product' => $inactivatedProduct,
-      'plan' => $inactivatedPlan,
-    );
+        return array(
+          'product' => $inactivatedProduct,
+          'plan' => $inactivatedPlan,
+        );
   }
 
   /**
@@ -469,37 +469,37 @@ class PlansController
    */
   function untrash($post_id)
   {
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
 
-    $product = wc_get_product($post_id);
-    // Check if the post is of the signature type
-    if (!in_array($product->get_type(), $this->allowedTypes)) {
-      return;
-    }
+        $product = wc_get_product($post_id);
+        // Check if the post is of the signature type
+        if (!in_array($product->get_type(), $this->allowedTypes)) {
+          return;
+        }
 
-    $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
-    $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
+        $vindi_product_id = get_post_meta($product->id, 'vindi_product_id', true);
+        $vindi_plan_id = get_post_meta($product->id, 'vindi_plan_id', true);
 
-    if (empty($vindi_product_id) || empty($vindi_plan_id)) {
-      return;
-    }
+        if (empty($vindi_product_id) || empty($vindi_plan_id)) {
+          return;
+        }
 
-    // Changes the product status within the Vindi
-    $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-      'status' => 'active',
-    ));
+        // Changes the product status within the Vindi
+        $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+          'status' => 'active',
+        ));
 
-    // Changes the plan status within the Vindi
-    $activatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
-      'status' => 'active',
-    ));
+        // Changes the plan status within the Vindi
+        $activatedPlan = $this->routes->updatePlan($vindi_plan_id, array(
+          'status' => 'active',
+        ));
 
-    return array(
-      'product' => $activatedProduct,
-      'plan' => $activatedPlan,
-    );
+        return array(
+          'product' => $activatedProduct,
+          'plan' => $activatedPlan,
+        );
   }
 }

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -75,8 +75,13 @@ class PlansController
 
     // Check if it's a new post
     // The $update value is unreliable because of the auto_draft functionality
-        if (!$recreated && get_post_status($post_id) != 'publish' ||(!empty(get_post_meta($post_id, 'vindi_plan_id', true)))) {
-            return $this->update($post_id);
+    $post_status = get_post_status($post_id);
+    $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id', true);
+
+        if (!$recreated && $post_status != 'publish') {
+            if (!empty($vindi_plan_id)) {
+                return $this->update($post_id);
+            }
         }
 
     $product = wc_get_product($post_id);
@@ -102,7 +107,7 @@ class PlansController
         $plan_interval     = VindiConversions::convert_interval($interval_count, $interval_type);
                 $variation_id      = $variation['variation_id'];
 
-        $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
+                $plan_installments = $variation_product->get_meta("vindi_max_credit_installments_$variation_id");
 
                 if (!$plan_installments || $plan_installments === 0) {
                     $plan_installments = 1;
@@ -117,7 +122,7 @@ class PlansController
         $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
         $createdProduct = !empty($vindi_product_id) ?
           $this->routes->findProductById($vindi_product_id) :
-                    $this->routes->createProduct(
+                      $this->routes->createProduct(
                       array(
                         'name' => VINDI_PREFIX_PRODUCT . $data['name'],
                         'code' => 'WC-' . $data['id'],
@@ -154,13 +159,13 @@ class PlansController
         $variations_plans[$variation['variation_id']] = $createdPlan;
 
         // Saving product id and plan in the WC goal
-                    if (isset($variation['variation_id']) && $createdProduct['id']) {
-                          update_post_meta($variation['variation_id'], 'vindi_product_id', $createdProduct['id']);
-                    }
+                      if (isset($variation['variation_id']) && $createdProduct['id']) {
+                            update_post_meta($variation['variation_id'], 'vindi_product_id', $createdProduct['id']);
+                      }
 
-                    if (isset($variation['variation_id']) && $createdPlan['id']) {
-                          update_post_meta($variation['variation_id'], 'vindi_plan_id', $createdPlan['id']);
-                    }
+                        if (isset($variation['variation_id']) && $createdPlan['id']) {
+                            update_post_meta($variation['variation_id'], 'vindi_plan_id', $createdPlan['id']);
+                        }
       }
 
             $product_id = end($variations_products)['id'];

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -23,9 +23,18 @@ class PlansController
    */
   private $routes;
 
+  /**
+   * @var VindiLogger
+   */
+  private $logger;
+
+  /**
+   * @var array
+   */
+  private $allowed_types;
+
   function __construct(VindiSettings $vindi_settings)
   {
-
     $this->routes = $vindi_settings->routes;
     $this->logger = $vindi_settings->logger;
 

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -24,6 +24,16 @@ class ProductController
    */
   private $routes;
 
+  /**
+   * @var VindiLogger
+   */
+  private $logger;
+
+  /**
+   * @var array
+   */
+  private $ignored_types;
+
   function __construct(VindiSettings $vindi_settings)
   {
 

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -16,23 +16,23 @@ class ProductController
 
   /**
    * @var array
-   */
-  private $types;
+  */
+    private $types;
 
   /**
    * @var VindiRoutes
-   */
-  private $routes;
+  */
+    private $routes;
 
   /**
    * @var VindiLogger
-   */
-  private $logger;
+  */
+    private $logger;
 
   /**
    * @var array
-   */
-  private $ignored_types;
+  */
+    private $ignoredTypes;
 
   function __construct(VindiSettings $vindi_settings)
   {
@@ -45,7 +45,7 @@ class ProductController
      * Basically they are the same as the PlansController, but
      * the check is reversed to ignore this types
      */
-    $this->ignored_types = array('variable-subscription', 'subscription');
+    $this->ignoredTypes = array('variable-subscription', 'subscription');
 
     add_action('wp_insert_post', array($this, 'create'), 10, 3);
     add_action('wp_trash_post', array($this, 'trash'), 10, 1);
@@ -84,7 +84,7 @@ class ProductController
     $product = wc_get_product($post_id);
 
     // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignored_types)) {
+    if (in_array($product->get_type(), $this->ignoredTypes)) {
       return;
     }
 
@@ -119,7 +119,7 @@ class ProductController
     $product = wc_get_product($post_id);
 
     // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignored_types)) {
+    if (in_array($product->get_type(), $this->ignoredTypes)) {
       return;
     }
 
@@ -173,7 +173,7 @@ class ProductController
     $product = wc_get_product($post_id);
 
     // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignored_types)) {
+    if (in_array($product->get_type(), $this->ignoredTypes)) {
       return;
     }
 
@@ -207,7 +207,7 @@ class ProductController
     $product = wc_get_product($post_id);
 
     // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignored_types)) {
+    if (in_array($product->get_type(), $this->ignoredTypes)) {
       return;
     }
 

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -60,7 +60,7 @@ class ProductController
    * @SuppressWarnings(PHPMD.MissingImport)
    */
   function create($post_id, $post, $update, $recreated = false)
-      {
+  {
         // Check if the post is a draft
         if (strpos(get_post_status($post_id), 'draft') !== false) {
           return;
@@ -70,9 +70,9 @@ class ProductController
           return;
         }
             $post_meta = new PostMeta();
-            if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-                update_post_meta($post_id, 'vindi_product_id', '');
-            }
+        if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
+            update_post_meta($post_id, 'vindi_product_id', '');
+        }
 
         // Check if it's a new post
         // The $update value is unreliable because of the auto_draft functionality
@@ -102,12 +102,12 @@ class ProductController
         ));
 
               // Saving product id and plan in the WC goal
-              if ($createdProduct && isset($createdProduct['id'])) {
-                update_post_meta( $post_id, 'vindi_product_id', $createdProduct['id'] );
-                set_transient('vindi_product_message', 'created', 60);
-              } else {
-                set_transient('vindi_product_message', 'error', 60);
-              }
+          if ($createdProduct && isset($createdProduct['id'])) {
+            update_post_meta( $post_id, 'vindi_product_id', $createdProduct['id'] );
+            set_transient('vindi_product_message', 'created', 60);
+          } else {
+            set_transient('vindi_product_message', 'error', 60);
+          }
 
         return $createdProduct;
   }

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -36,20 +36,19 @@ class ProductController
 
   function __construct(VindiSettings $vindi_settings)
   {
+        $this->routes = $vindi_settings->routes;
+        $this->logger = $vindi_settings->logger;
 
-    $this->routes = $vindi_settings->routes;
-    $this->logger = $vindi_settings->logger;
+        /**
+         * Define wich product types to NOT handle in this controller.
+         * Basically they are the same as the PlansController, but
+         * the check is reversed to ignore this types
+         */
+        $this->ignoredTypes = array('variable-subscription', 'subscription');
 
-    /**
-     * Define wich product types to NOT handle in this controller.
-     * Basically they are the same as the PlansController, but
-     * the check is reversed to ignore this types
-     */
-    $this->ignoredTypes = array('variable-subscription', 'subscription');
-
-    add_action('wp_insert_post', array($this, 'create'), 10, 3);
-    add_action('wp_trash_post', array($this, 'trash'), 10, 1);
-    add_action('untrash_post', array($this, 'untrash'), 10, 1);
+        add_action('wp_insert_post', array($this, 'create'), 10, 3);
+        add_action('wp_trash_post', array($this, 'trash'), 10, 1);
+        add_action('untrash_post', array($this, 'untrash'), 10, 1);
   }
 
   /**
@@ -61,100 +60,99 @@ class ProductController
    * @SuppressWarnings(PHPMD.MissingImport)
    */
   function create($post_id, $post, $update, $recreated = false)
-  {
-    // Check if the post is a draft
-    if (strpos(get_post_status($post_id), 'draft') !== false) {
-      return;
-    }
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
-        $post_meta = new PostMeta();
-        if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
-            update_post_meta($post_id, 'vindi_product_id', '');
+      {
+        // Check if the post is a draft
+        if (strpos(get_post_status($post_id), 'draft') !== false) {
+          return;
+        }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
+            $post_meta = new PostMeta();
+            if ($post_meta->check_vindi_item_id($post_id, 'vindi_product_id') > 1) {
+                update_post_meta($post_id, 'vindi_product_id', '');
+            }
+
+        // Check if it's a new post
+        // The $update value is unreliable because of the auto_draft functionality
+        if(!$recreated && get_post_status($post_id) != 'publish' || !empty(get_post_meta($post_id, 'vindi_product_id', true))) {
+          return $this->update($post_id);
         }
 
-    // Check if it's a new post
-    // The $update value is unreliable because of the auto_draft functionality
-    if(!$recreated && get_post_status($post_id) != 'publish' || !empty(get_post_meta($post_id, 'vindi_product_id', true))) {
-      return $this->update($post_id);
-    }
+        $product = wc_get_product($post_id);
 
-    $product = wc_get_product($post_id);
+        // Check if the post is NOT of the subscription type
+        if (in_array($product->get_type(), $this->ignoredTypes)) {
+          return;
+        }
 
-    // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignoredTypes)) {
-      return;
-    }
+        $data = $product->get_data();
 
-    $data = $product->get_data();
+        // Creates the product within the Vindi
+        $createdProduct = $this->routes->createProduct(array(
+          'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+          'code' => 'WC-' . $data['id'],
+          'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+          'invoice' => 'always',
+          'pricing_schema' => array(
+            'price' => ($data['price']) ? $data['price'] : 0,
+            'schema_type' => 'flat',
+          )
+        ));
 
-    // Creates the product within the Vindi
-    $createdProduct = $this->routes->createProduct(array(
-      'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-      'code' => 'WC-' . $data['id'],
-      'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-      'invoice' => 'always',
-      'pricing_schema' => array(
-        'price' => ($data['price']) ? $data['price'] : 0,
-        'schema_type' => 'flat',
-      )
-    ));
+              // Saving product id and plan in the WC goal
+              if ($createdProduct && isset($createdProduct['id'])) {
+                update_post_meta( $post_id, 'vindi_product_id', $createdProduct['id'] );
+                set_transient('vindi_product_message', 'created', 60);
+              } else {
+                set_transient('vindi_product_message', 'error', 60);
+              }
 
-          // Saving product id and plan in the WC goal
-          if ($createdProduct && isset($createdProduct['id'])) {
-            update_post_meta( $post_id, 'vindi_product_id', $createdProduct['id'] );
-            set_transient('vindi_product_message', 'created', 60);
-          } else {
-            set_transient('vindi_product_message', 'error', 60);
-          }
-
-    return $createdProduct;
+        return $createdProduct;
   }
 
   function update($post_id)
   {
+        $product = wc_get_product($post_id);
 
-    $product = wc_get_product($post_id);
+        // Check if the post is NOT of the subscription type
+        if (in_array($product->get_type(), $this->ignoredTypes)) {
+          return;
+        }
 
-    // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignoredTypes)) {
-      return;
-    }
+        // Checks whether there is a vindi product ID associated within
+        $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
 
-    // Checks whether there is a vindi product ID associated within
-    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
+        if(empty($vindi_product_id)) {
 
-    if(empty($vindi_product_id)) {
+          return $this->create($post_id, '', '', true);
+        }
 
-      return $this->create($post_id, '', '', true);
-    }
+        $data = $product->get_data();
 
-    $data = $product->get_data();
+        // Updates the product within the Vindi
+        $updatedProduct = $this->routes->updateProduct(
+          $vindi_product_id,
+          array(
+            'name' => VINDI_PREFIX_PRODUCT . $data['name'],
+            'code' => 'WC-' . $data['id'],
+            'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+            'invoice' => 'always',
+            'pricing_schema' => array(
+              'price' => ($data['price']) ? $data['price'] : 0,
+              'schema_type' => 'flat',
+            )
+          )
+        );
 
-    // Updates the product within the Vindi
-    $updatedProduct = $this->routes->updateProduct(
-      $vindi_product_id,
-      array(
-        'name' => VINDI_PREFIX_PRODUCT . $data['name'],
-        'code' => 'WC-' . $data['id'],
-        'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
-        'invoice' => 'always',
-        'pricing_schema' => array(
-          'price' => ($data['price']) ? $data['price'] : 0,
-          'schema_type' => 'flat',
-        )
-      )
-    );
+        if($updatedProduct) {
+          set_transient('vindi_product_message', 'updated', 60);
+        } else {
+          set_transient('vindi_product_message', 'error', 60);
+        }
 
-    if($updatedProduct) {
-      set_transient('vindi_product_message', 'updated', 60);
-    } else {
-      set_transient('vindi_product_message', 'error', 60);
-    }
-
-    return $updatedProduct;
+        return $updatedProduct;
   }
 
   /**
@@ -165,30 +163,30 @@ class ProductController
    */
   function trash($post_id)
   {
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
 
-    $product = wc_get_product($post_id);
+        $product = wc_get_product($post_id);
 
-    // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignoredTypes)) {
-      return;
-    }
+        // Check if the post is NOT of the subscription type
+        if (in_array($product->get_type(), $this->ignoredTypes)) {
+          return;
+        }
 
-    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
+        $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
 
-    if(empty($vindi_product_id)) {
-      return;
-    }
+        if(empty($vindi_product_id)) {
+          return;
+        }
 
-    // Changes the product status within the Vindi
-    $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-      'status' => 'inactive',
-    ));
+        // Changes the product status within the Vindi
+        $inactivatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+          'status' => 'inactive',
+        ));
 
-    return $inactivatedProduct;
+        return $inactivatedProduct;
   }
 
   /**
@@ -199,29 +197,29 @@ class ProductController
    */
   function untrash($post_id)
   {
-    // Check if the post is product
-    if (get_post_type($post_id) != 'product') {
-      return;
-    }
+        // Check if the post is product
+        if (get_post_type($post_id) != 'product') {
+          return;
+        }
 
-    $product = wc_get_product($post_id);
+        $product = wc_get_product($post_id);
 
-    // Check if the post is NOT of the subscription type
-    if (in_array($product->get_type(), $this->ignoredTypes)) {
-      return;
-    }
+        // Check if the post is NOT of the subscription type
+        if (in_array($product->get_type(), $this->ignoredTypes)) {
+          return;
+        }
 
-    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
+        $vindi_product_id = get_post_meta($post_id, 'vindi_product_id', true);
 
-    if(empty($vindi_product_id)) {
-      return;
-    }
+        if(empty($vindi_product_id)) {
+          return;
+        }
 
-    // Changes the product status within the Vindi
-    $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
-      'status' => 'active',
-    ));
+        // Changes the product status within the Vindi
+        $activatedProduct = $this->routes->updateProduct($vindi_product_id, array(
+          'status' => 'active',
+        ));
 
-    return $activatedProduct;
+        return $activatedProduct;
   }
 }

--- a/src/includes/gateways/CreditPayment.php
+++ b/src/includes/gateways/CreditPayment.php
@@ -279,7 +279,7 @@ class VindiCreditGateway extends VindiPaymentGateway
           $payment_profile = $this->routes->getPaymentProfile($user_vindi_id);
         }
 
-        if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard'){
+        if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard') {
           return $user_payment_profile;
         }
 

--- a/src/includes/gateways/CreditPayment.php
+++ b/src/includes/gateways/CreditPayment.php
@@ -19,303 +19,303 @@ if (!defined('ABSPATH')) {
 
 class VindiCreditGateway extends VindiPaymentGateway
 {
-  /**
-   * @var VindiSettings
-   */
-  public $vindi_settings;
+    /**
+     * @var VindiSettings
+     */
+    public $vindi_settings;
 
-  /**
-   * @var VindiControllers
-   */
-  public $controllers;
+    /**
+     * @var VindiControllers
+     */
+    public $controllers;
 
-  /**
-   * @var int
-   */
-  private $max_installments = 12;
+    /**
+     * @var int
+     */
+    private $max_installments = 12;
 
-  /**
-   * @var int
-   */
-  public $interest_rate;
+    /**
+     * @var int
+     */
+    public $interest_rate;
 
-  public $smallest_installment;
-  public $installments;
-  public $verify_method;
-  public $enable_interest_rate;
+    public $smallest_installment;
+    public $installments;
+    public $verify_method;
+    public $enable_interest_rate;
 
-  public function __construct(VindiSettings $vindi_settings, VindiControllers $controllers)
-  {
+    public function __construct(VindiSettings $vindi_settings, VindiControllers $controllers)
+    {
 
-    global $woocommerce;
+      global $woocommerce;
 
-    $this->id                   = 'vindi-credit-card';
-    $this->icon                 = apply_filters('vindi_woocommerce_credit_card_icon', '');
-    $this->method_title         = __('Vindi - Cartão de Crédito', VINDI);
-    $this->method_description   = __('Aceitar pagamentos via cartão de crédito utilizando a Vindi.', VINDI);
-    $this->has_fields           = true;
+      $this->id                   = 'vindi-credit-card';
+      $this->icon                 = apply_filters('vindi_woocommerce_credit_card_icon', '');
+      $this->method_title         = __('Vindi - Cartão de Crédito', VINDI);
+      $this->method_description   = __('Aceitar pagamentos via cartão de crédito utilizando a Vindi.', VINDI);
+      $this->has_fields           = true;
 
-    $this->supports             = array(
-      'subscriptions',
-      'products',
-      'subscription_cancellation',
-      'subscription_reactivation',
-      'subscription_suspension',
-      'subscription_amount_changes',
-      'subscription_payment_method_change',
-      'subscription_payment_method_change_customer',
-      'subscription_payment_method_change_admin',
-      'subscription_date_changes',
-      'multiple_subscriptions',
-      'refunds',
-      'pre-orders'
-    );
-
-    $this->init_form_fields();
-    $this->init_settings();
-
-    $this->smallest_installment = $this->get_option('smallest_installment');
-    $this->installments = $this->get_option('installments');
-    $this->verify_method = $this->get_option('verify_method');
-    $this->enable_interest_rate = $this->get_option('enable_interest_rate');
-    $this->interest_rate = $this->get_option('interest_rate');
-
-    parent::__construct($vindi_settings, $controllers);
-  }
-
-  /**
-   * Should return payment type for payment processing.
-   * @return string
-   */
-  public function type()
-  {
-    return 'cc';
-  }
-
-  public function init_form_fields()
-  {
-
-    $this->form_fields = array(
-      'enabled' => array(
-        'title'   => __('Habilitar/Desabilitar', VINDI),
-        'label'   => __('Habilitar pagamento via Cartão de Crédito com a Vindi', VINDI),
-        'type'    => 'checkbox',
-        'default' => 'no',
-      ),
-      'title' => array(
-        'title'       => __('Título', VINDI),
-        'type'        => 'text',
-        'description' => __('Título que o cliente verá durante o processo de pagamento.', VINDI),
-        'default'     => __('Cartão de Crédito', VINDI),
-      ),
-      'verify_method' => array(
-        'title'       => __('Transação de Verificação', VINDI),
-        'type'        => 'checkbox',
-        'description' => __(' Realiza a transação de verificação em todos os novos pedidos. (Taxas adicionais por verificação poderão ser cobradas).', VINDI),
-        'default'     => 'no',
-      ),
-      'single_charge' => array(
-        'title' => __('Vendas Avulsas', VINDI),
-        'type'  => 'title',
-      ),
-      'smallest_installment' => array(
-        'title'       => __('Valor mínimo da parcela', VINDI),
-        'type'        => 'text',
-        'description' => __('Valor mínimo da parcela, não deve ser inferior a R$ 5,00.', VINDI),
-        'default'     => '5',
-      ),
-      'installments' => array(
-        'title'       => __('Número máximo de parcelas', VINDI),
-        'type'        => 'select',
-        'description' => __('Número máximo de parcelas para vendas avulsas. Deixe em 1x para desativar o parcelamento.', VINDI),
-        'default'     => '1',
-        'options'     => array(
-          '1'  => '1x',
-          '2'  => '2x',
-          '3'  => '3x',
-          '4'  => '4x',
-          '5'  => '5x',
-          '6'  => '6x',
-          '7'  => '7x',
-          '8'  => '8x',
-          '9'  => '9x',
-          '10' => '10x',
-          '11' => '11x',
-          '12' => '12x',
-        ),
-      ),
-      'enable_interest_rate' => array(
-        'title'       => __('Habilitar juros', VINDI),
-        'type'        => 'checkbox',
-        'description' => __('Habilitar juros no parcelamento do pedido.', VINDI),
-        'default'     => 'no',
-      ),
-      'interest_rate' => array(
-        'title'       => __('Taxa de juros ao mês (%)', VINDI),
-        'type'        => 'text',
-        'description' => __('Taxa de juros que será adicionada aos pagamentos parcelados.', VINDI),
-        'default'     => '0.1',
-      )
-    );
-  }
-
-  public function payment_fields()
-  {
-    $cart = $this->vindi_settings->woocommerce->cart;
-    $total = $this->get_cart_total($cart);
-
-    $installments = $this->build_cart_installments($total);
-
-    $user_payment_profile = $this->build_user_payment_profile();
-    $payment_methods = $this->routes->getPaymentMethods();
-
-    if ($payment_methods === false || empty($payment_methods) || !count($payment_methods['credit_card'])) {
-      _e(
-        'Estamos enfrentando problemas técnicos no momento. Tente novamente mais tarde ou entre em contato.',
-        VINDI
+      $this->supports             = array(
+        'subscriptions',
+        'products',
+        'subscription_cancellation',
+        'subscription_reactivation',
+        'subscription_suspension',
+        'subscription_amount_changes',
+        'subscription_payment_method_change',
+        'subscription_payment_method_change_customer',
+        'subscription_payment_method_change_admin',
+        'subscription_date_changes',
+        'multiple_subscriptions',
+        'refunds',
+        'pre-orders'
       );
-      return;
+
+      $this->init_form_fields();
+      $this->init_settings();
+
+      $this->smallest_installment = $this->get_option('smallest_installment');
+      $this->installments = $this->get_option('installments');
+      $this->verify_method = $this->get_option('verify_method');
+      $this->enable_interest_rate = $this->get_option('enable_interest_rate');
+      $this->interest_rate = $this->get_option('interest_rate');
+
+      parent::__construct($vindi_settings, $controllers);
     }
-    $is_trial = false;
-    if (isset($this->is_trial) && $this->is_trial == $this->vindi_settings->get_is_active_sandbox()) {
-      $is_trial = $this->routes->isMerchantStatusTrialOrSandbox();
+
+    /**
+     * Should return payment type for payment processing.
+     * @return string
+     */
+    public function type()
+    {
+      return 'cc';
     }
 
-    $this->vindi_settings->get_template('creditcard-checkout.html.php', compact(
-      'installments',
-      'is_trial',
-      'user_payment_profile',
-      'payment_methods'
-    ));
-  }
+    public function init_form_fields()
+    {
 
-  public function build_cart_installments($total)
-  {
-    $max_times = $this->get_order_max_installments($total);
-    $installments = [];
+      $this->form_fields = array(
+        'enabled' => array(
+          'title'   => __('Habilitar/Desabilitar', VINDI),
+          'label'   => __('Habilitar pagamento via Cartão de Crédito com a Vindi', VINDI),
+          'type'    => 'checkbox',
+          'default' => 'no',
+        ),
+        'title' => array(
+          'title'       => __('Título', VINDI),
+          'type'        => 'text',
+          'description' => __('Título que o cliente verá durante o processo de pagamento.', VINDI),
+          'default'     => __('Cartão de Crédito', VINDI),
+        ),
+        'verify_method' => array(
+          'title'       => __('Transação de Verificação', VINDI),
+          'type'        => 'checkbox',
+          'description' => __(' Realiza a transação de verificação em todos os novos pedidos. (Taxas adicionais por verificação poderão ser cobradas).', VINDI),
+          'default'     => 'no',
+        ),
+        'single_charge' => array(
+          'title' => __('Vendas Avulsas', VINDI),
+          'type'  => 'title',
+        ),
+        'smallest_installment' => array(
+          'title'       => __('Valor mínimo da parcela', VINDI),
+          'type'        => 'text',
+          'description' => __('Valor mínimo da parcela, não deve ser inferior a R$ 5,00.', VINDI),
+          'default'     => '5',
+        ),
+        'installments' => array(
+          'title'       => __('Número máximo de parcelas', VINDI),
+          'type'        => 'select',
+          'description' => __('Número máximo de parcelas para vendas avulsas. Deixe em 1x para desativar o parcelamento.', VINDI),
+          'default'     => '1',
+          'options'     => array(
+            '1'  => '1x',
+            '2'  => '2x',
+            '3'  => '3x',
+            '4'  => '4x',
+            '5'  => '5x',
+            '6'  => '6x',
+            '7'  => '7x',
+            '8'  => '8x',
+            '9'  => '9x',
+            '10' => '10x',
+            '11' => '11x',
+            '12' => '12x',
+          ),
+        ),
+        'enable_interest_rate' => array(
+          'title'       => __('Habilitar juros', VINDI),
+          'type'        => 'checkbox',
+          'description' => __('Habilitar juros no parcelamento do pedido.', VINDI),
+          'default'     => 'no',
+        ),
+        'interest_rate' => array(
+          'title'       => __('Taxa de juros ao mês (%)', VINDI),
+          'type'        => 'text',
+          'description' => __('Taxa de juros que será adicionada aos pagamentos parcelados.', VINDI),
+          'default'     => '0.1',
+        )
+      );
+    }
 
-    if ($max_times > 1) {
-      for ($times = 1; $times <= $max_times; $times++) {
-        $installments[$times] = $this->get_cart_installments($times, $total);
+    public function payment_fields()
+    {
+        $cart = $this->vindi_settings->woocommerce->cart;
+        $total = $this->get_cart_total($cart);
+
+        $installments = $this->build_cart_installments($total);
+
+        $user_payment_profile = $this->build_user_payment_profile();
+        $payment_methods = $this->routes->getPaymentMethods();
+
+        if ($payment_methods === false || empty($payment_methods) || !count($payment_methods['credit_card'])) {
+            _e(
+              'Estamos enfrentando problemas técnicos no momento. Tente novamente mais tarde ou entre em contato.',
+              VINDI
+            );
+          return;
+        }
+        $is_trial = false;
+        if (isset($this->is_trial) && $this->is_trial == $this->vindi_settings->get_is_active_sandbox()) {
+            $is_trial = $this->routes->isMerchantStatusTrialOrSandbox();
+        }
+
+      $this->vindi_settings->get_template('creditcard-checkout.html.php', compact(
+        'installments',
+        'is_trial',
+        'user_payment_profile',
+        'payment_methods'
+      ));
+    }
+
+    public function build_cart_installments($total)
+    {
+        $max_times = $this->get_order_max_installments($total);
+        $installments = [];
+
+        if ($max_times > 1) {
+            for ($times = 1; $times <= $max_times; $times++) {
+                $installments[$times] = $this->get_cart_installments($times, $total);
+            }
+        }
+
+        return $installments;
+    }
+
+    public function get_cart_installments($times, $total)
+    {
+        if ($this->is_interest_rate_enabled()) {
+            return ($total * (1 + (($this->get_interest_rate() / 100) * ($times - 1)))) / $times;
+        }
+
+        return ceil($total / $times * 100) / 100;
+    }
+
+    public function get_cart_total($cart)
+    {
+        $total = $cart->total;
+        $recurring = end($cart->recurring_carts);
+
+        if (floatval($cart->total) == 0 && is_object($recurring)) {
+            $total = $recurring->total;
+        }
+
+        foreach ($cart->get_fees() as $index => $fee) {
+            if ($fee->name == __('Juros', VINDI)) {
+                $total -= $fee->amount;
+            }
+        }
+
+        return $total;
+    }
+
+    public function verify_user_payment_profile()
+    {
+      $old_payment_profile = (int) filter_input(
+        INPUT_POST,
+        'vindi-old-cc-data-check',
+        FILTER_SANITIZE_NUMBER_INT
+      );
+
+      return 1 === $old_payment_profile;
+    }
+
+    public function verify_method()
+    {
+      return 'yes' === $this->verify_method;
+    }
+
+    public function is_interest_rate_enabled()
+    {
+      return 'yes' === $this->enable_interest_rate;
+    }
+
+    public function get_interest_rate()
+    {
+      return floatval($this->interest_rate);
+    }
+
+    protected function get_order_max_installments($order_total)
+    {
+      if ($this->is_single_order()) {
+        $order_max_times = floor($order_total / $this->smallest_installment);
+        $max_times = empty($order_max_times) ? 1 : $order_max_times;
+
+        return min($this->max_installments, $max_times, $this->get_installments());
       }
+      return $this->get_installments();
     }
 
-    return $installments;
-  }
 
-  public function get_cart_installments($times, $total)
-  {
-    if ($this->is_interest_rate_enabled()) {
-      return ($total * (1 + (($this->get_interest_rate() / 100) * ($times - 1)))) / $times;
+    private function build_user_payment_profile()
+    {
+        $user_payment_profile = array();
+        $user_vindi_id = get_user_meta(wp_get_current_user()->ID, 'vindi_customer_id', true);
+        $payment_profile = WC()->session->get('current_payment_profile');
+        $current_customer = WC()->session->get('current_customer');
+
+        if (!isset($payment_profile) || ($current_customer['code'] ?? null) != $user_vindi_id) {
+          $payment_profile = $this->routes->getPaymentProfile($user_vindi_id);
+        }
+
+        if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard')
+          return $user_payment_profile;
+
+        if (false === empty($payment_profile)) {
+          $user_payment_profile['holder_name']     = $payment_profile['holder_name'];
+          $user_payment_profile['payment_company'] = $payment_profile['payment_company']['code'];
+          $user_payment_profile['card_number']     = sprintf('**** **** **** %s', $payment_profile['card_number_last_four']);
+        }
+
+        WC()->session->set('current_payment_profile', $payment_profile);
+        return $user_payment_profile;
     }
 
-    return ceil($total / $times * 100) / 100;
-  }
+    protected function get_installments()
+    {
+      if ($this->is_single_order())
+        return $this->installments;
 
-  public function get_cart_total($cart)
-  {
-    $total = $cart->total;
-    $recurring = end($cart->recurring_carts);
+      $installments = 0;
 
-    if (floatval($cart->total) == 0 && is_object($recurring)) {
-      $total = $recurring->total;
-    }
+      foreach ($this->vindi_settings->woocommerce->cart->cart_contents as $item) {
+        $plan_id = $item['data']->get_meta('vindi_plan_id');
 
-    foreach ($cart->get_fees() as $index => $fee) {
-      if ($fee->name == __('Juros', VINDI)) {
-        $total -= $fee->amount;
-      }
-    }
+        if (!empty($plan_id)) {
+          $plan = $this->routes->getPlan($plan_id);
 
-    return $total;
-  }
-
-  public function verify_user_payment_profile()
-  {
-    $old_payment_profile = (int) filter_input(
-      INPUT_POST,
-      'vindi-old-cc-data-check',
-      FILTER_SANITIZE_NUMBER_INT
-    );
-
-    return 1 === $old_payment_profile;
-  }
-
-  public function verify_method()
-  {
-    return 'yes' === $this->verify_method;
-  }
-
-  public function is_interest_rate_enabled()
-  {
-    return 'yes' === $this->enable_interest_rate;
-  }
-
-  public function get_interest_rate()
-  {
-    return floatval($this->interest_rate);
-  }
-
-  protected function get_order_max_installments($order_total)
-  {
-    if ($this->is_single_order()) {
-      $order_max_times = floor($order_total / $this->smallest_installment);
-      $max_times = empty($order_max_times) ? 1 : $order_max_times;
-
-      return min($this->max_installments, $max_times, $this->get_installments());
-    }
-    return $this->get_installments();
-  }
-
-
-  private function build_user_payment_profile()
-  {
-    $user_payment_profile = array();
-    $user_vindi_id = get_user_meta(wp_get_current_user()->ID, 'vindi_customer_id', true);
-    $payment_profile = WC()->session->get('current_payment_profile');
-    $current_customer = WC()->session->get('current_customer');
-
-    if (!isset($payment_profile) || ($current_customer['code'] ?? null) != $user_vindi_id) {
-      $payment_profile = $this->routes->getPaymentProfile($user_vindi_id);
-    }
-
-    if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard')
-      return $user_payment_profile;
-
-    if (false === empty($payment_profile)) {
-      $user_payment_profile['holder_name']     = $payment_profile['holder_name'];
-      $user_payment_profile['payment_company'] = $payment_profile['payment_company']['code'];
-      $user_payment_profile['card_number']     = sprintf('**** **** **** %s', $payment_profile['card_number_last_four']);
-    }
-
-    WC()->session->set('current_payment_profile', $payment_profile);
-    return $user_payment_profile;
-  }
-
-  protected function get_installments()
-  {
-    if ($this->is_single_order())
-      return $this->installments;
-
-    $installments = 0;
-
-    foreach ($this->vindi_settings->woocommerce->cart->cart_contents as $item) {
-      $plan_id = $item['data']->get_meta('vindi_plan_id');
-
-      if (!empty($plan_id)) {
-        $plan = $this->routes->getPlan($plan_id);
-
-        if ($installments == 0) {
-          $installments = $plan['installments'];
-        } elseif ($plan['installments'] < $installments) {
-          $installments = $plan['installments'];
+          if ($installments == 0) {
+            $installments = $plan['installments'];
+          } elseif ($plan['installments'] < $installments) {
+            $installments = $plan['installments'];
+          }
         }
       }
-    }
 
-    if ($installments != 0)
-      return $installments;
-    else
-      return 1;
-  }
+      if ($installments != 0)
+        return $installments;
+      else
+        return 1;
+    }
 }

--- a/src/includes/gateways/CreditPayment.php
+++ b/src/includes/gateways/CreditPayment.php
@@ -171,8 +171,8 @@ class VindiCreditGateway extends VindiPaymentGateway
 
         if ($payment_methods === false || empty($payment_methods) || !count($payment_methods['credit_card'])) {
             _e(
-              'Estamos enfrentando problemas técnicos no momento. Tente novamente mais tarde ou entre em contato.',
-              VINDI
+                'Estamos enfrentando problemas técnicos no momento. Tente novamente mais tarde ou entre em contato.',
+                VINDI
             );
           return;
         }
@@ -182,10 +182,10 @@ class VindiCreditGateway extends VindiPaymentGateway
         }
 
       $this->vindi_settings->get_template('creditcard-checkout.html.php', compact(
-        'installments',
-        'is_trial',
-        'user_payment_profile',
-        'payment_methods'
+          'installments',
+          'is_trial',
+          'user_payment_profile',
+          'payment_methods'
       ));
     }
 
@@ -279,8 +279,9 @@ class VindiCreditGateway extends VindiPaymentGateway
           $payment_profile = $this->routes->getPaymentProfile($user_vindi_id);
         }
 
-        if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard')
+        if (($payment_profile['type'] ?? null) !== 'PaymentProfile::CreditCard'){
           return $user_payment_profile;
+        }
 
         if (false === empty($payment_profile)) {
           $user_payment_profile['holder_name']     = $payment_profile['holder_name'];

--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -401,15 +401,17 @@ class VindiRoutes
 
   public function isMerchantStatusTrialOrSandbox($is_config = false)
   {
-    if ('yes' === isset($this->sandbox))
-      return true;
+        if ('yes' === isset($this->sandbox)){
+            return true;
+        }
 
-    $merchant = $is_config ? $this->getMerchant($is_config) : $this->getMerchant();
+      $merchant = $is_config ? $this->getMerchant($is_config) : $this->getMerchant();
 
-    if ('trial' === $merchant['status'])
-      return true;
+        if ('trial' === $merchant['status']){
+          return true;
+        }
 
-    return false;
+      return false;
   }
 
   public function getMerchant($is_config = false)
@@ -441,7 +443,7 @@ class VindiRoutes
   /**
    * @var array|bool|mixed
    */
-  public $current_plan;
+    public $current_plan;
 
   public function getPlan($plan_id)
   {

--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -15,6 +15,7 @@ class VindiRoutes
    */
   public $api;
 
+
   function __construct(VindiSettings $vindi_settings)
   {
 
@@ -400,7 +401,7 @@ class VindiRoutes
 
   public function isMerchantStatusTrialOrSandbox($is_config = false)
   {
-    if ('yes' === $this->sandbox)
+    if ('yes' === isset($this->sandbox))
       return true;
 
     $merchant = $is_config ? $this->getMerchant($is_config) : $this->getMerchant();
@@ -436,6 +437,11 @@ class VindiRoutes
 
     return $response['charge'];
   }
+
+  /**
+   * @var array|bool|mixed
+   */
+  public $current_plan;
 
   public function getPlan($plan_id)
   {

--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -401,13 +401,13 @@ class VindiRoutes
 
   public function isMerchantStatusTrialOrSandbox($is_config = false)
   {
-        if ('yes' === isset($this->sandbox)){
+        if ('yes' === isset($this->sandbox)) {
             return true;
         }
 
       $merchant = $is_config ? $this->getMerchant($is_config) : $this->getMerchant();
 
-        if ('trial' === $merchant['status']){
+        if ('trial' === $merchant['status']) {
           return true;
         }
 
@@ -443,7 +443,7 @@ class VindiRoutes
   /**
    * @var array|bool|mixed
    */
-    public $current_plan;
+  public $current_plan;
 
   public function getPlan($plan_id)
   {

--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -443,7 +443,7 @@ class VindiRoutes
   /**
    * @var array|bool|mixed
    */
-  public $current_plan;
+    public $current_plan;
 
   public function getPlan($plan_id)
   {

--- a/src/templates/bankslip-checkout.html.php
+++ b/src/templates/bankslip-checkout.html.php
@@ -9,11 +9,11 @@
 	</div>
 <?php endif; ?>
 <fieldset>
-	<?php
-	if (isset($id)) {
-		do_action('vindi_bank_slip_form_start', $id);
-	}
-	?>
+<?php
+if (isset($id)){
+	do_action('vindi_bank_slip_form_start', $id);
+}
+?>
 
 	<div class="vindi-invoice-description" style="padding: 20px 0; font-weight: bold;">
 		<?php
@@ -26,10 +26,11 @@
 	</div>
 	<div class="clear"></div>
 
-	<?php
-	if (isset($id)) {
-		do_action('vindi_bank_slip_form_end', $id);
-	}
-	?>
+<?php
+if (isset($id)) {
+    do_action('vindi_bank_slip_form_end', $id);
+}
+?>
+
 	<div class="clear"></div>
 </fieldset>

--- a/src/templates/bankslip-checkout.html.php
+++ b/src/templates/bankslip-checkout.html.php
@@ -1,16 +1,16 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 
 <?php if ($is_trial) : ?>
-	<div style="padding: 10px;border: 1px solid #f00; background-color: #fdd; color: #f00; margin: 10px 2px">
+    <div style="padding: 10px;border: 1px solid #f00; background-color: #fdd; color: #f00; margin: 10px 2px">
 		<h3 style="color: #f00"><?php _e('MODO DE TESTES', VINDI); ?></h3>
 		<p>
 			<?php _e('Sua conta na Vindi está em <strong>Modo Trial</strong>. Este modo é proposto para a realização de testes e, portanto, nenhum pedido será efetivamente cobrado.', VINDI); ?>
 		</p>
-	</div>
+    </div>
 <?php endif; ?>
 <fieldset>
 <?php
-if (isset($id)){
+if (isset($id)) {
 	do_action('vindi_bank_slip_form_start', $id);
 }
 ?>

--- a/src/templates/bankslip-checkout.html.php
+++ b/src/templates/bankslip-checkout.html.php
@@ -1,15 +1,14 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 
-<?php if ($is_trial): ?>
-    <div style="padding: 10px;border: 1px solid #f00; background-color: #fdd; color: #f00; margin: 10px 2px">
-    	<h3 style="color: #f00"><?php _e('MODO DE TESTES', VINDI); ?></h3>
-    	<p>
-    		<?php _e('Sua conta na Vindi está em <strong>Modo Trial</strong>. Este modo é proposto para a realização de testes e, portanto, nenhum pedido será efetivamente cobrado.', VINDI); ?>
-    	</p>
-    </div>
+<?php if ($is_trial) : ?>
+	<div style="padding: 10px;border: 1px solid #f00; background-color: #fdd; color: #f00; margin: 10px 2px">
+		<h3 style="color: #f00"><?php _e('MODO DE TESTES', VINDI); ?></h3>
+		<p>
+			<?php _e('Sua conta na Vindi está em <strong>Modo Trial</strong>. Este modo é proposto para a realização de testes e, portanto, nenhum pedido será efetivamente cobrado.', VINDI); ?>
+		</p>
+	</div>
 <?php endif; ?>
 <fieldset>
-
 	<?php
 	if (isset($id)) {
 		do_action('vindi_bank_slip_form_start', $id);
@@ -18,7 +17,7 @@
 
 	<div class="vindi-invoice-description" style="padding: 20px 0; font-weight: bold;">
 		<?php
-		if ($is_single_order){
+		if ($is_single_order) {
 			_e('Um Boleto Bancário será enviado para o seu endereço de e-mail.', VINDI);
 		} else {
 			_e('Um boleto bancário será enviado para o seu e-mail de acordo com a sua assinatura. ', VINDI);

--- a/src/templates/bankslip-checkout.html.php
+++ b/src/templates/bankslip-checkout.html.php
@@ -11,7 +11,7 @@
 <fieldset>
 <?php
 if (isset($id)) {
-	do_action('vindi_bank_slip_form_start', $id);
+    do_action('vindi_bank_slip_form_start', $id);
 }
 ?>
 

--- a/src/templates/bankslip-checkout.html.php
+++ b/src/templates/bankslip-checkout.html.php
@@ -10,7 +10,11 @@
 <?php endif; ?>
 <fieldset>
 
-	<?php do_action('vindi_bank_slip_form_start', $id); ?>
+	<?php
+	if (isset($id)) {
+		do_action('vindi_bank_slip_form_start', $id);
+	}
+	?>
 
 	<div class="vindi-invoice-description" style="padding: 20px 0; font-weight: bold;">
 		<?php
@@ -23,7 +27,10 @@
 	</div>
 	<div class="clear"></div>
 
-	<?php do_action('vindi_bank_slip_form_end', $id); ?>
-
+	<?php
+	if (isset($id)) {
+		do_action('vindi_bank_slip_form_end', $id);
+	}
+	?>
 	<div class="clear"></div>
 </fieldset>

--- a/src/templates/creditcard-checkout.html.php
+++ b/src/templates/creditcard-checkout.html.php
@@ -12,9 +12,9 @@
 <fieldset class="vindi-fieldset">
 
 <?php
-  if (isset($id)) {
-      do_action('vindi_credit_card_form_start', $id);
-  }
+if (isset($id)) {
+    do_action('vindi_credit_card_form_start', $id);
+}
 ?>
 
   <?php if(!empty($user_payment_profile)): ?>
@@ -201,11 +201,11 @@
     </p>
     <?php endif; ?>
   <div class="clear"></div>
-  <?php
-  if (isset($id)) {
-      do_action('vindi_credit_card_form_end', $id);
-  }
-  ?>
+    <?php
+    if (isset($id)) {
+        do_action('vindi_credit_card_form_end', $id);
+    }
+    ?>
 
   <div class="clear"></div>
 </fieldset>

--- a/src/templates/creditcard-checkout.html.php
+++ b/src/templates/creditcard-checkout.html.php
@@ -11,7 +11,11 @@
 
 <fieldset class="vindi-fieldset">
 
-  <?php do_action('vindi_credit_card_form_start', $id); ?>
+<?php
+  if (isset($id)) {
+      do_action('vindi_credit_card_form_start', $id);
+  }
+?>
 
   <?php if(!empty($user_payment_profile)): ?>
     <div class="vindi-old-cc-data">
@@ -197,8 +201,11 @@
     </p>
     <?php endif; ?>
   <div class="clear"></div>
-
-  <?php do_action('vindi_credit_card_form_end', $id); ?>
+  <?php
+  if (isset($id)) {
+      do_action('vindi_credit_card_form_end', $id);
+  }
+  ?>
 
   <div class="clear"></div>
 </fieldset>

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.2.5');
+define('VINDI_VERSION', '1.2.6');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -79,7 +79,6 @@ class VindiPaymentProcessor
         $this->routes = $vindi_settings->routes;
         $this->controllers = $controllers;
         $this->single_freight = $this->vindi_settings->get_option('shipping_and_tax_config') == "yes" ? true : false;
-
     }
 
     /**
@@ -270,7 +269,7 @@ class VindiPaymentProcessor
         $this->check_trial_and_single_product();
         $customer = $this->get_customer();
         $order_items = $this->order->get_items();
-        
+
         $bills = [];
         $order_post_meta = [];
         $bill_products = [];
@@ -301,7 +300,7 @@ class VindiPaymentProcessor
         $this->check_multiple_subscriptions_of_same_period($subscriptions_grouped_by_period);
 
         foreach ($subscription_products as $subscription_order_item) {
-            if(empty($subscription_order_item))
+            if (empty($subscription_order_item))
                 continue;
 
             try {
@@ -408,7 +407,6 @@ class VindiPaymentProcessor
         if ($this->gateway->verify_method()) {
             $this->verify_payment_profile($payment_profile['id']);
         }
-
     }
 
     /**
@@ -424,7 +422,6 @@ class VindiPaymentProcessor
         if (!$this->routes->verifyCustomerPaymentProfile($payment_profile_id)) {
             $this->abort(__('Não foi possível realizar a verificação do seu cartão de crédito!', VINDI), true);
         }
-
     }
 
     /**
@@ -446,10 +443,8 @@ class VindiPaymentProcessor
         if ($item['type'] == 'shipping' || $item['type'] == 'tax') {
             if ($this->vindi_settings->get_shipping_and_tax_config()) {
                 return 1;
-
             }
             return $this->single_freight ? 1 : null;
-
         } elseif (!$product || !$this->is_subscription_type($product)) {
             return 1;
         }
@@ -546,7 +541,6 @@ class VindiPaymentProcessor
                 $order_items[$key]['type'] = 'product';
                 $order_items[$key]['vindi_id'] = $this->routes->findProductByCode('WC-' . $product->id)['id'];
                 $order_items[$key]['price'] = (float) $order_items[$key]['subtotal'] / $order_items[$key]['qty'];
-
             }
             return $order_items;
         }
@@ -887,8 +881,10 @@ class VindiPaymentProcessor
         } elseif (strpos($discount_type, 'fixed') !== false) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $amount;
-        } elseif (strpos($discount_type, 'percent') !== false ||
-                  strpos($discount_type, 'recurring_percent') !== false) {
+        } elseif (
+            strpos($discount_type, 'percent') !== false ||
+            strpos($discount_type, 'recurring_percent') !== false
+        ) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $this->order->get_discount_total() / $this->order->get_item_count();
         }
@@ -998,7 +994,7 @@ class VindiPaymentProcessor
      */
     protected function create_subscription($customer_id, $order_item)
     {
-        if($order_item == null || empty($order_item)) {
+        if ($order_item == null || empty($order_item)) {
             return;
         }
         $data = [];
@@ -1044,7 +1040,7 @@ class VindiPaymentProcessor
     {
         $this->suspend_subscriptions($subscriptions_ids);
 
-        foreach($wc_subscriptions_ids as $wc_subscription_id) {
+        foreach ($wc_subscriptions_ids as $wc_subscription_id) {
             $wc_subscription = wcs_get_subscription($wc_subscription_id);
             $wc_subscription->update_status('cancelled', __($message, VINDI));
         }
@@ -1180,10 +1176,12 @@ class VindiPaymentProcessor
         $this->vindi_settings->woocommerce->cart->empty_cart();
         $bills_status = [];
         foreach ($bills as $bill) {
-            $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $bill['id'], $this->order->get_id());
+            $fatura = $bill['id'];
+            $pedido = $this->order->get_id();
+            $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $fatura, $pedido);
             $status_message = __('Aguardando pagamento do pedido.', VINDI);
             if ($bill['status'] == 'paid') {
-                $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $bill['id'], $this->order->get_id());
+                $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $fatura, $pedido);
                 $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI);
             }
             array_push($bills_status, $bill['status']);
@@ -1192,7 +1190,8 @@ class VindiPaymentProcessor
         $status = 'pending';
         if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();
-        } if ($this->order_has_trial()) {
+        }
+        if ($this->order_has_trial()) {
             $status = $this->vindi_settings->get_return_status();
             $status_message = __('Aguardando cobrança após a finalização do período grátis.', VINDI);
         }
@@ -1212,7 +1211,7 @@ class VindiPaymentProcessor
      * @return WC_Product Woocommerce product array with a vindi id
      */
     protected function get_product($order_item)
-     {
+    {
 
         $product = $order_item->get_product();
         $product_id = $order_item->get_id();
@@ -1230,11 +1229,10 @@ class VindiPaymentProcessor
 
         if (empty($vindi_product_id) || !$vindi_product_id) {
             $vindi_product_id = $this->routes->findProductByCode('WC-' . $product->id)['id'];
-
         }
 
         $product->vindi_id = (int) $vindi_product_id > 0 ? $vindi_product_id : 63;
-        if($product->id === null) $product->id = 63;
+        if ($product->id === null) $product->id = 63;
 
         return $product;
     }
@@ -1257,13 +1255,11 @@ class VindiPaymentProcessor
                 if ($has_simple_product) {
                     return true;
                 }
-
             } else {
                 $has_simple_product = true;
                 if ($has_trial) {
                     return true;
                 }
-
             }
         }
         return $has_trial && $has_simple_product;
@@ -1277,7 +1273,7 @@ class VindiPaymentProcessor
      */
     protected function is_variable(WC_Product $product)
     {
-        return (boolean) preg_match('/variation/', $product->get_type());
+        return (bool) preg_match('/variation/', $product->get_type());
     }
 
     /**
@@ -1288,7 +1284,7 @@ class VindiPaymentProcessor
      */
     protected function is_subscription_type(WC_Product $product)
     {
-        return (boolean) preg_match('/subscription/', $product->get_type());
+        return (bool) preg_match('/subscription/', $product->get_type());
     }
 
     /**
@@ -1344,6 +1340,5 @@ class VindiPaymentProcessor
         } catch (Exception $err) {
             return $product;
         }
-
     }
 }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -59,6 +59,8 @@ class VindiPaymentProcessor
      */
     private $controllers;
 
+    private $single_freight;
+
     /**
      * Payment Processor contructor.
      *
@@ -281,7 +283,7 @@ class VindiPaymentProcessor
             $product = $order_item->get_product();
 
             if ($this->is_subscription_type($product)) {
-                $product_id = $product->id;
+                $product_id = $product->get_id();
 
                 if ($this->is_variable($product)) {
                     $product_id = $order_item['variation_id'];
@@ -312,7 +314,7 @@ class VindiPaymentProcessor
 
                 $subscription_bill = $subscription['bill'];
                 $order_post_meta[$subscription_id]['cycle'] = $subscription['current_period']['cycle'];
-                $order_post_meta[$subscription_id]['product'] = $subscription_order_item->get_product()->name;
+                $order_post_meta[$subscription_id]['product'] = $subscription_order_item->get_product()->get_name();
                 $order_post_meta[$subscription_id]['bill'] = $this->create_bill_meta_for_order($subscription_bill);
 
                 $bills[] = $subscription['bill'];
@@ -352,7 +354,7 @@ class VindiPaymentProcessor
             }
         }
 
-        update_post_meta($this->order->id, 'vindi_order', $order_post_meta);
+        update_post_meta($this->order->get_id(), 'vindi_order', $order_post_meta);
         WC()->session->__unset('current_payment_profile');
         WC()->session->__unset('current_customer');
         remove_action('woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal');
@@ -551,7 +553,7 @@ class VindiPaymentProcessor
 
         $product = $order_items->get_product();
         $order_items['type'] = 'product';
-        $product_id = $product->id;
+        $product_id = $product->get_id();
 
         if ($this->is_variable($product)) {
             $product_id = $order_items['variation_id'];
@@ -1007,7 +1009,7 @@ class VindiPaymentProcessor
         $product = $order_item->get_product();
         if ($this->is_subscription_type($product) || $this->is_variable($product)) {
             $data['plan_id'] = $this->get_plan_from_order_item($order_item);
-            $wc_subscription_id = VindiHelpers::get_matching_subscription($this->order, $order_item)->id;
+            $wc_subscription_id = VindiHelpers::get_matching_subscription($this->order, $order_item)->get_id();
             $data['code'] = strpos($wc_subscription_id, 'WC') > 0 ? $wc_subscription_id : 'WC-' . $wc_subscription_id;
         }
         $data['product_items'] = $this->get_build_products($data, $order_item);
@@ -1018,7 +1020,7 @@ class VindiPaymentProcessor
         }
         $subscription['wc_id'] = $wc_subscription_id;
         if (isset($subscription['bill']['id'])) {
-            update_post_meta($this->order->id, 'vindi_bill_id', $subscription['bill']['id']);
+            update_post_meta($this->order->get_id(), 'vindi_bill_id', $subscription['bill']['id']);
         }
         return $subscription;
     }
@@ -1179,10 +1181,10 @@ class VindiPaymentProcessor
         $bills_status = [];
         foreach ($bills as $bill) {
             if ($bill['status'] == 'paid') {
-                $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $bill['id'], $this->order->id);
+                $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $bill['id'], $this->order->get_id());
                 $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI);
             } else {
-                $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $bill['id'], $this->order->id);
+                $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $bill['id'], $this->order->get_id());
                 $status_message = __('Aguardando pagamento do pedido.', VINDI);
             }
             array_push($bills_status, $bill['status']);

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1204,6 +1204,7 @@ class VindiPaymentProcessor
     private function update_order_status($bills_status)
     {
         $status = 'pending';
+        $status_message = '';
         if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();
         }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1180,22 +1180,21 @@ class VindiPaymentProcessor
         $this->vindi_settings->woocommerce->cart->empty_cart();
         $bills_status = [];
         foreach ($bills as $bill) {
+            $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $bill['id'], $this->order->get_id());
+            $status_message = __('Aguardando pagamento do pedido.', VINDI);
             if ($bill['status'] == 'paid') {
                 $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $bill['id'], $this->order->get_id());
                 $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI);
-            } else {
-                $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $bill['id'], $this->order->get_id());
-                $status_message = __('Aguardando pagamento do pedido.', VINDI);
             }
             array_push($bills_status, $bill['status']);
             $this->logger->log($data_to_log);
         }
         $status = 'pending';
-        if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid')) || $this->order_has_trial()) {
+        if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();
-            if ($this->order_has_trial()) {
-                $status_message = __('Aguardando cobrança após a finalização do período grátis.', VINDI);
-            }
+        } if ($this->order_has_trial()) {
+            $status = $this->vindi_settings->get_return_status();
+            $status_message = __('Aguardando cobrança após a finalização do período grátis.', VINDI);
         }
         $this->order->update_status($status, $status_message);
         return array(

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -79,6 +79,7 @@ class VindiPaymentProcessor
         $this->routes = $vindi_settings->routes;
         $this->controllers = $controllers;
         $this->single_freight = $this->vindi_settings->get_option('shipping_and_tax_config') == "yes" ? true : false;
+
     }
 
     /**
@@ -269,7 +270,7 @@ class VindiPaymentProcessor
         $this->check_trial_and_single_product();
         $customer = $this->get_customer();
         $order_items = $this->order->get_items();
-
+        
         $bills = [];
         $order_post_meta = [];
         $bill_products = [];
@@ -300,7 +301,7 @@ class VindiPaymentProcessor
         $this->check_multiple_subscriptions_of_same_period($subscriptions_grouped_by_period);
 
         foreach ($subscription_products as $subscription_order_item) {
-            if (empty($subscription_order_item))
+            if(empty($subscription_order_item))
                 continue;
 
             try {
@@ -407,6 +408,7 @@ class VindiPaymentProcessor
         if ($this->gateway->verify_method()) {
             $this->verify_payment_profile($payment_profile['id']);
         }
+
     }
 
     /**
@@ -422,6 +424,7 @@ class VindiPaymentProcessor
         if (!$this->routes->verifyCustomerPaymentProfile($payment_profile_id)) {
             $this->abort(__('Não foi possível realizar a verificação do seu cartão de crédito!', VINDI), true);
         }
+
     }
 
     /**
@@ -443,8 +446,10 @@ class VindiPaymentProcessor
         if ($item['type'] == 'shipping' || $item['type'] == 'tax') {
             if ($this->vindi_settings->get_shipping_and_tax_config()) {
                 return 1;
+
             }
             return $this->single_freight ? 1 : null;
+
         } elseif (!$product || !$this->is_subscription_type($product)) {
             return 1;
         }
@@ -541,6 +546,7 @@ class VindiPaymentProcessor
                 $order_items[$key]['type'] = 'product';
                 $order_items[$key]['vindi_id'] = $this->routes->findProductByCode('WC-' . $product->id)['id'];
                 $order_items[$key]['price'] = (float) $order_items[$key]['subtotal'] / $order_items[$key]['qty'];
+
             }
             return $order_items;
         }
@@ -881,10 +887,8 @@ class VindiPaymentProcessor
         } elseif (strpos($discount_type, 'fixed') !== false) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $amount;
-        } elseif (
-            strpos($discount_type, 'percent') !== false ||
-            strpos($discount_type, 'recurring_percent') !== false
-        ) {
+        } elseif (strpos($discount_type, 'percent') !== false ||
+                  strpos($discount_type, 'recurring_percent') !== false) {
             $discount_item['discount_type'] = 'amount';
             $discount_item['amount'] = $this->order->get_discount_total() / $this->order->get_item_count();
         }
@@ -994,7 +998,7 @@ class VindiPaymentProcessor
      */
     protected function create_subscription($customer_id, $order_item)
     {
-        if ($order_item == null || empty($order_item)) {
+        if($order_item == null || empty($order_item)) {
             return;
         }
         $data = [];
@@ -1040,7 +1044,7 @@ class VindiPaymentProcessor
     {
         $this->suspend_subscriptions($subscriptions_ids);
 
-        foreach ($wc_subscriptions_ids as $wc_subscription_id) {
+        foreach($wc_subscriptions_ids as $wc_subscription_id) {
             $wc_subscription = wcs_get_subscription($wc_subscription_id);
             $wc_subscription->update_status('cancelled', __($message, VINDI));
         }
@@ -1176,12 +1180,10 @@ class VindiPaymentProcessor
         $this->vindi_settings->woocommerce->cart->empty_cart();
         $bills_status = [];
         foreach ($bills as $bill) {
-            $fatura = $bill['id'];
-            $pedido = $this->order->get_id();
-            $data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.', $fatura, $pedido);
+$data_to_log = sprintf('Aguardando pagamento da fatura %s do pedido %s pela Vindi.',$bill['id'],$this->order->get_id());
             $status_message = __('Aguardando pagamento do pedido.', VINDI);
             if ($bill['status'] == 'paid') {
-                $data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.', $fatura, $pedido);
+$data_to_log = sprintf('O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.',$bill['id'], $this->order->get_id());
                 $status_message = __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI);
             }
             array_push($bills_status, $bill['status']);
@@ -1190,8 +1192,7 @@ class VindiPaymentProcessor
         $status = 'pending';
         if (sizeof($bills_status) == sizeof(array_keys($bills_status, 'paid'))) {
             $status = $this->vindi_settings->get_return_status();
-        }
-        if ($this->order_has_trial()) {
+        } if ($this->order_has_trial()) {
             $status = $this->vindi_settings->get_return_status();
             $status_message = __('Aguardando cobrança após a finalização do período grátis.', VINDI);
         }
@@ -1211,7 +1212,7 @@ class VindiPaymentProcessor
      * @return WC_Product Woocommerce product array with a vindi id
      */
     protected function get_product($order_item)
-    {
+     {
 
         $product = $order_item->get_product();
         $product_id = $order_item->get_id();
@@ -1229,10 +1230,11 @@ class VindiPaymentProcessor
 
         if (empty($vindi_product_id) || !$vindi_product_id) {
             $vindi_product_id = $this->routes->findProductByCode('WC-' . $product->id)['id'];
+
         }
 
         $product->vindi_id = (int) $vindi_product_id > 0 ? $vindi_product_id : 63;
-        if ($product->id === null) $product->id = 63;
+        if($product->id === null) $product->id = 63;
 
         return $product;
     }
@@ -1255,11 +1257,13 @@ class VindiPaymentProcessor
                 if ($has_simple_product) {
                     return true;
                 }
+
             } else {
                 $has_simple_product = true;
                 if ($has_trial) {
                     return true;
                 }
+
             }
         }
         return $has_trial && $has_simple_product;
@@ -1273,7 +1277,7 @@ class VindiPaymentProcessor
      */
     protected function is_variable(WC_Product $product)
     {
-        return (bool) preg_match('/variation/', $product->get_type());
+        return (boolean) preg_match('/variation/', $product->get_type());
     }
 
     /**
@@ -1284,7 +1288,7 @@ class VindiPaymentProcessor
      */
     protected function is_subscription_type(WC_Product $product)
     {
-        return (bool) preg_match('/subscription/', $product->get_type());
+        return (boolean) preg_match('/subscription/', $product->get_type());
     }
 
     /**
@@ -1340,5 +1344,6 @@ class VindiPaymentProcessor
         } catch (Exception $err) {
             return $product;
         }
+
     }
 }

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1181,7 +1181,7 @@ class VindiPaymentProcessor
         $bills_status = [];
         foreach ($bills as $bill) {
             array_push($bills_status, $bill['status']);
-            $this->logger->log($this->generate_log_message($bill));
+            $this->generate_log_message($bill);
         }
         $this->update_order_status($bills_status);
         return array(
@@ -1198,7 +1198,7 @@ class VindiPaymentProcessor
         if ($bill['status'] == 'paid') {
             $message = 'O Pagamento da fatura %s do pedido %s foi realizado com sucesso pela Vindi.';
         }
-        return sprintf($message, $fatura, $pedido);
+        $this->logger->log(sprintf($message, $fatura, $pedido));
     }
 
     private function update_order_status($bills_status)

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -8,6 +8,11 @@ class VindiSubscriptionStatusHandler
      * @var VindiSettings
      */
     private $vindi_settings;
+    
+    /**
+     * @var VindiRoutes
+     */
+    private $routes;
 
     public function __construct(VindiSettings $vindi_settings)
     {
@@ -157,12 +162,10 @@ class VindiSubscriptionStatusHandler
         $single_payment_bill_id = 0;
 
         foreach ($vindi_order as $key => $item) {
-            if ($key == 'single_payment' &&
-                $vindi_order[$key]['bill']['status'] != 'canceled') {
+            if (isset($vindi_order[$key]['bill']['status']) && $vindi_order[$key]['bill']['status'] !== 'canceled') {
                 $single_payment_bill_id = $vindi_order[$key]['bill']['id'];
+                $vindi_order[$key]['bill']['status'] = 'canceled';
             }
-
-            $vindi_order[$key]['bill']['status'] = 'canceled';
         }
         
         update_post_meta($order->id, 'vindi_order', $vindi_order);

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.2.5
+ * Version: 1.2.6
  * Requires at least: 4.4
  * Tested up to: 6.3
  * WC requires at least: 3.0.0


### PR DESCRIPTION
Antes de efetuar qualquer pagamento ou compra, o plugin Vindi apresenta erros relacionados à criação de propriedades dinâmicas em várias de suas classes.

Plano de Ação:

PlansController.php

Erro: Variáveis não declaradas.
Solução: Foram declaradas as variáveis $logger e $allowed_types.
ProductController.php

Erro: Variáveis não declaradas.
Solução: Foram declaradas as variáveis $logger e $ignored_types.
SubscriptionStatusHandler.php

Erro: Variáveis não declaradas.
Solução: Foram declaradas as variáveis $routes.
CreditPayment.php

Erro: Variáveis não declaradas.
Solução: Foram declaradas as variáveis $smallest_installment, $installments, $verify_method e $enable_interest_rate.
Após uma tentativa de pagamento ou compra, o debug.log do sistema apresenta os mesmos erros de criação de propriedades dinâmicas, mas agora em outras classes.

RoutesApi.php

Erro: Variáveis não declaradas.
Solução: Foi declarada a variável $current_plan.
CreditPayment.php

Erro: Variáveis não declaradas.
Solução: Foi adicionada a condição isset($this->is_trial), pois o is_trial poderia não existir.
creditcard-checkout.html.php

Erro: Variáveis não declaradas.
Solução: Foi adicionada a condição isset($id), pois o $id poderia não existir, evitando erro no do_action('vindi_credit_card_form_start', $id).
bankslip-checkout.html.php

Erro: Variáveis não declaradas.
Solução: Foi adicionada a condição isset($id), pois o $id poderia não existir, evitando erro no do_action('vindi_bank_slip_form_start', $id).
Após efetuar o pagamento, o plugin apresentou problemas com a forma que o id e name estavam sendo chamados pelo arquivo PaymentProcessor.php. Onde estava escrito $order->id, passou a estar $order->get_id() e $order->name para $order->get_name().

Com essas alterações feitas o debug.log não apresentou mais falhas sobre o plugin da Vindi, sendo assim compatível com as versões mais atualizadas do WC, Wordpress e PHP 8.3