### PR TITLE
Forçando persistência de dados para meta values de pedidos

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Tested up to: 6.4
 WC requires at least: 3.0.0
 WC tested up to: 8.6.1
 Requires PHP: 5.6
-Stable Tag: 1.2.8
+Stable Tag: 1.2.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -39,6 +39,11 @@ Para dúvidas e suporte técnico, entre em contato com a equipe Vindi através d
 5. Configurações de pagamentos via cartão de crédito
 
 == Changelog ==
+
+= 1.2.9 - 18/04/2024 =
+-Lançamento da versão de patch.
+- **Correção:** Utilização da função save durante atualização de metadados com HPOS
+- **Correção:** Bug durante renovação de assinaturas
 
 = 1.2.8 - 05/04/2024 =
 -Lançamento da versão de patch.

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -123,6 +123,7 @@ class VindiWebhooks
       'bank_slip_url' => $renew_infos['bill_print_url'],
     );
         $order->update_meta_data('vindi_order', $order_post_meta);
+        $order->save();
     $this->vindi_settings->logger->log('Novo Período criado: Pedido #'.$order->id);
 
     // We've already processed the renewal
@@ -202,6 +203,7 @@ class VindiWebhooks
         $order->update_status($new_status, __('O Pagamento foi realizado com sucesso pela Vindi.', VINDI));
         $this->update_next_payment($data);
     }
+        $order->save();
   }
 
   /**

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VINDI_VERSION', '1.2.8');
+define('VINDI_VERSION', '1.2.9');
 
 define('VINDI_MININUM_WP_VERSION', '5.0');
 define('VINDI_MININUM_PHP_VERSION', '5.6');

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1010,9 +1010,7 @@ class VindiPaymentProcessor
      */
     protected function create_subscription($customer_id, $order_item)
     {
-        if($order_item == null || empty($order_item)) {
-            return;
-        }
+        if($order_item == null || empty($order_item)) return;
         $data = [];
         $data['customer_id'] = $customer_id;
         $data['payment_method_code'] = $this->payment_method_code();

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1010,7 +1010,9 @@ class VindiPaymentProcessor
      */
     protected function create_subscription($customer_id, $order_item)
     {
-        if ($order_item == null || empty($order_item)) { return; }
+        if ($order_item == null || empty($order_item)) {
+            return;
+        }
         $data = [];
         $data['customer_id'] = $customer_id;
         $data['payment_method_code'] = $this->payment_method_code();
@@ -1025,8 +1027,7 @@ class VindiPaymentProcessor
         $data['product_items'] = $this->get_build_products($data, $order_item);
         $subscription = $this->routes->createSubscription($data);
         if (!isset($subscription['id']) || empty($subscription['id'])) {
-            $message = sprintf(__('Pagamento Falhou. (%s)', VINDI), $this->vindi_settings->api->last_error);
-            throw new Exception($message);
+            throw new Exception(sprintf(__('Pagamento Falhou. (%s)', VINDI), $this->vindi_settings->api->last_error));
         }
         $subscription['wc_id'] = $wc_subscription_id;
         if (isset($subscription['bill']['id'])) {

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -1010,7 +1010,7 @@ class VindiPaymentProcessor
      */
     protected function create_subscription($customer_id, $order_item)
     {
-        if($order_item == null || empty($order_item)) return;
+        if ($order_item == null || empty($order_item)) { return; }
         $data = [];
         $data['customer_id'] = $customer_id;
         $data['payment_method_code'] = $this->payment_method_code();

--- a/src/utils/PaymentProcessor.php
+++ b/src/utils/PaymentProcessor.php
@@ -366,6 +366,7 @@ class VindiPaymentProcessor
         }
 
         $this->order->update_meta_data('vindi_order', $order_post_meta);
+        $this->order->save();
         WC()->session->__unset('current_payment_profile');
         WC()->session->__unset('current_customer');
         remove_action('woocommerce_scheduled_subscription_payment', 'WC_Subscriptions_Manager::prepare_renewal');
@@ -1032,6 +1033,7 @@ class VindiPaymentProcessor
         $subscription['wc_id'] = $wc_subscription_id;
         if (isset($subscription['bill']['id'])) {
             $this->order->update_meta_data('vindi_bill_id', $subscription['bill']['id']);
+            $this->order->save();
         }
         return $subscription;
     }
@@ -1099,7 +1101,7 @@ class VindiPaymentProcessor
 
         if ($bill['id']) {
             $this->logger->log(sprintf('Update Bill: %s', json_encode($bill)));
-            $this->order->update_meta_data('vindi_bill_id', $bill['id']);
+            $this->order->save();
         }
         return $bill;
     }

--- a/src/utils/SubscriptionStatusHandler.php
+++ b/src/utils/SubscriptionStatusHandler.php
@@ -169,6 +169,7 @@ class VindiSubscriptionStatusHandler
         }
         
         $order->update_meta_data('vindi_order', $vindi_order);
+        $order->save();
 
         if ($single_payment_bill_id) {
             $this->routes->deleteBill($single_payment_bill_id);

--- a/vindi.php
+++ b/vindi.php
@@ -6,7 +6,7 @@
  * Description: Adiciona o gateway de pagamento da Vindi para o WooCommerce.
  * Author: Vindi
  * Author URI: https://www.vindi.com.br
- * Version: 1.2.8
+ * Version: 1.2.9
  * Requires at least: 4.4
  * Tested up to: 6.4
  * Text Domain: vindi-payment-gateway


### PR DESCRIPTION
## O que mudou
Foi adicionado chamadas da função save() do objeto WC_Order do WooCommerce após todas as utilizações da função update_meta_data(), também do WooCommerce.

## Motivação
Essa função save() força o salvamento da informação inserida na função update_meta_data(), garantindo que a informação não seja perdida.
Não sabemos o motivo da instabilidade da função update_meta_data(), mas em alguns casos a função salva as informações em outros casos não.

## Solução proposta
Foi adicionado chamadas da função save() do objeto WC_Order do WooCommerce após todas as utilizações da função update_meta_data(), também do WooCommerce.

## Como testar
Realizar o fluxo de compra de assinatura, renovação e baixa de assinatura.